### PR TITLE
[#33] Pull Request 올리면 Assignee 본인으로 자동으로 세팅되도록 github aciton 구축

### DIFF
--- a/.github/workflows/auto-set-assignee.yaml
+++ b/.github/workflows/auto-set-assignee.yaml
@@ -1,0 +1,31 @@
+name: Auto Set Assignee
+
+on: 
+  pull_request:
+    types: [opened]
+
+jobs:
+  assign:
+    runs-on: ubuntu-latest
+    steps:
+      - name: set assignees
+        uses: actions/github-script@v7
+        with:
+          github-token: ${{ secrets.GITHUB_TOKEN }}
+          script: |
+            const { owner, repo } = context.repo
+            const prNumber = context.payload.pull_request.number
+            const response = await github.rest.issues.get({
+              owner,
+              repo,
+              issue_number: prNumber,
+            })
+            const { assignees } = response.data
+            if (assignees.length === 0) {
+              await github.rest.issues.addAssignees({
+                owner: owner,
+                repo: repo,
+                issue_number: prNumber,
+                assignees: [context.actor]
+              })
+            }


### PR DESCRIPTION
## 개요
🔑**이슈 링크** : https://github.com/mash-up-kr/DHC-Android/issues/33


## 💻작업 내용  
- PR 올리면 Assignees 세팅 안해도 PR 올린 본인으로 세팅되도록 github action 추가


## 👾시연 화면 (option)  
-

## Close 
close #33
