### PR TITLE
[#36] PR 실패하면 코멘트 달리게 설정

### DIFF
--- a/.github/workflows/detekt-check.yaml
+++ b/.github/workflows/detekt-check.yaml
@@ -18,5 +18,32 @@ jobs:
         run: chmod +x gradlew
 
       - name: Run detekt
-        run: ./gradlew detekt
+        id: detekt
+        run: |
+          ./gradlew detekt > detekt-result.txt
 
+      - name : detekt result
+        if: failure()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            const fs = require('fs');
+            const result = fs.readFileSync('detekt-result.txt', 'utf8');
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `## ☠️ detekt 실패 ☠️ \n\n${result}`
+            })
+
+      - name: detekt result
+        if: success()
+        uses: actions/github-script@v7
+        with:
+          script: |
+            github.rest.issues.createComment({
+              issue_number: context.issue.number,
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              body: `## 🎉 detekt 성공 🎉`
+            })


### PR DESCRIPTION
## 개요
🔑**이슈 링크** : https://github.com/mash-up-kr/DHC-Android/issues/36


## 💻작업 내용  
- detekt 가 실패하면 실패한 내용이 코멘트 달립니다.
- detekt 잘못된 부분 수정해서 자동으로 고쳐주는건 개발하지 못했지만,, 어디가 잘못되었는지 코멘트로 보여줄 수 있도록 만들어보았습니다.


## 🗣️To Reviwers  
- 근데 쫌 코멘트가 길어서 드러운거같긴한데, 그냥 기존처럼 직접 action 들어가서 볼 수 있게 하는게 더 나으려나 고민 중


## 👾시연 화면 (option)  
은 바로 아래에서 확인해보실 수 있습니다.

## Close 
close #36
