### PR TITLE
[#44] PR 단계에서 빌드 정상동작 테스트하는 github action 제작 

### DIFF
--- a/.github/workflows/build-debug-check.yaml
+++ b/.github/workflows/build-debug-check.yaml
@@ -1,0 +1,23 @@
+name: detekt Auto Testing
+
+on:
+  pull_request:
+    branches: [ "feature/*" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'oracle'
+          java-version: '17'
+          cache: 'gradle'
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: run assembleDebug
+        run: ./gradlew assembleDebug

--- a/.github/workflows/build-debug-check.yaml
+++ b/.github/workflows/build-debug-check.yaml
@@ -1,4 +1,4 @@
-name: detekt Auto Testing
+name: debug build Testing
 
 on:
   pull_request:

--- a/.github/workflows/build-debug-check.yaml
+++ b/.github/workflows/build-debug-check.yaml
@@ -2,7 +2,7 @@ name: detekt Auto Testing
 
 on:
   pull_request:
-    branches: [ "feature/*" ]
+    branches: [ "feature/**" ]
 
 jobs:
   build:

--- a/.github/workflows/build-debug-check.yaml
+++ b/.github/workflows/build-debug-check.yaml
@@ -2,7 +2,7 @@ name: debug build Testing
 
 on:
   pull_request:
-    branches: [ "feature/**", "develop" ]
+    branches: [ "develop" ]
 
 jobs:
   build:

--- a/.github/workflows/build-debug-check.yaml
+++ b/.github/workflows/build-debug-check.yaml
@@ -2,7 +2,7 @@ name: detekt Auto Testing
 
 on:
   pull_request:
-    branches: [ "feature/**" ]
+    branches: [ "feature/**", "develop" ]
 
 jobs:
   build:

--- a/.github/workflows/build-release-check.yaml
+++ b/.github/workflows/build-release-check.yaml
@@ -2,7 +2,7 @@ name: detekt Auto Testing
 
 on:
   pull_request:
-    branches: [ "release/*", "hotfix/*" ]
+    branches: [ "release/**", "hotfix/**" ]
 
 jobs:
   build:

--- a/.github/workflows/build-release-check.yaml
+++ b/.github/workflows/build-release-check.yaml
@@ -1,0 +1,23 @@
+name: detekt Auto Testing
+
+on:
+  pull_request:
+    branches: [ "release/*", "hotfix/*" ]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'oracle'
+          java-version: '17'
+          cache: 'gradle'
+
+      - name: Grant execute permission for gradlew
+        run: chmod +x gradlew
+
+      - name: run assembleRelease
+        run: ./gradlew assembleRelease

--- a/.github/workflows/build-release-check.yaml
+++ b/.github/workflows/build-release-check.yaml
@@ -2,7 +2,7 @@ name: detekt Auto Testing
 
 on:
   pull_request:
-    branches: [ "release/**", "hotfix/**" ]
+    branches: [ "release/**", "hotfix/**", "develop" ]
 
 jobs:
   build:

--- a/.github/workflows/build-release-check.yaml
+++ b/.github/workflows/build-release-check.yaml
@@ -1,4 +1,4 @@
-name: detekt Auto Testing
+name: release build Testing
 
 on:
   pull_request:

--- a/.github/workflows/build-release-check.yaml
+++ b/.github/workflows/build-release-check.yaml
@@ -2,7 +2,7 @@ name: release build Testing
 
 on:
   pull_request:
-    branches: [ "release/**", "hotfix/**", "develop" ]
+    branches: [ "main", "release/**" ]
 
 jobs:
   build:

--- a/presentation/sample/src/main/java/com/dhc/sample/home/HomeScreen.kt
+++ b/presentation/sample/src/main/java/com/dhc/sample/home/HomeScreen.kt
@@ -39,7 +39,7 @@ fun HomeRoute(
     HomeScreen(
         state = state,
         eventHandler = viewModel::sendEvent,
-    )히히 버그지롱
+    )
 }
 
 @Composable

--- a/presentation/sample/src/main/java/com/dhc/sample/home/HomeScreen.kt
+++ b/presentation/sample/src/main/java/com/dhc/sample/home/HomeScreen.kt
@@ -39,7 +39,7 @@ fun HomeRoute(
     HomeScreen(
         state = state,
         eventHandler = viewModel::sendEvent,
-    )
+    )히히 버그지롱
 }
 
 @Composable


### PR DESCRIPTION
## 개요
🔑**이슈 링크** : https://github.com/mash-up-kr/DHC-Android/issues/44


## 💻작업 내용  
- 빌드 잘 되는지 테스트하는 깃헙 액션 만들기


## 🗣️To Reviwers  
- gitflow 정책에 기반하여 `develop` 으로 향하는 PR 은 debug build 테스트를 하고, `release/*`, `main` 으로 향하는 PR 은 release build 테스트를 하도록 구현하였습니다.

## 👾시연 화면 (option)  

|빌드 실패|빌드 성공|  
|:---|---|
|![image](https://github.com/user-attachments/assets/38855c83-f71e-4409-8248-7333fa3f8594)|![image](https://github.com/user-attachments/assets/8d04f43d-a144-498d-8ee5-e4dbf7a589d0)|

시연이미지는 둘  다 동작하는거 보려고 release, debug action 이 모두 돌아가게 의도적으로 세팅했었습니다.


## Close 
close #44
