### PR TITLE
[#55]  Kotlin Version upgrade (2.0.0 -> 2.0.21)

### DIFF
--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -1,6 +1,6 @@
 [versions]
 agp = "8.7.3"
-kotlin = "2.0.0"
+kotlin = "2.0.21"
 coreKtx = "1.15.0"
 junit = "4.13.2"
 junitVersion = "1.2.1"


### PR DESCRIPTION
## 개요
🔑**이슈 링크** : https://github.com/mash-up-kr/DHC-Android/issues/55

## 💻작업 내용  
- Kotlin Version upgrade (2.0.0 -> 2.0.21)
- 사유 : 2.0.20 버전부터 strong skipping mode 가 기본적으로 사용되어, immutableList 를 사용하지 않아도 List parameter 에서 recomposition 되는 이슈를 방지한다고 공지되어있기 때문
- ref : https://developer.android.com/develop/ui/compose/performance/stability/strongskipping?hl=ko#enable-strong

## 🗣️To Reviwers  
- 이대로 사용해보고 List parameter 넘겼는데 recomposition 발생하면 다시 고민해보자


## 👾시연 화면 (option)  
-

## Close 
close #55
