### PR TITLE
[#50] Proto Datastore 의존성 추가 및 Sample 코드 작성

### DIFF
--- a/data/build.gradle.kts
+++ b/data/build.gradle.kts
@@ -1,6 +1,9 @@
+import com.google.protobuf.gradle.id
+
 plugins {
     id("dhc.module")
     id("dhc.hilt")
+    alias(libs.plugins.protobuf)
 }
 
 android {
@@ -12,7 +15,28 @@ dependencies {
 
     implementation(libs.bundles.network)
 
+    implementation(libs.bundles.proto.datastore)
+
     debugImplementation(libs.bundles.flipper)
 
     testImplementation(libs.junit)
+}
+
+protobuf {
+    protoc {
+        artifact = "com.google.protobuf:protoc:3.25.0"
+    }
+
+    // Generates the java Protobuf-lite code for the Protobufs in this project. See
+    // https://github.com/google/protobuf-gradle-plugin#customizing-protobuf-compilation
+    // for more information.
+    generateProtoTasks {
+        all().forEach { task ->
+            task.plugins {
+                id("java") {
+                    option("lite")
+                }
+            }
+        }
+    }
 }

--- a/data/src/main/kotlin/com/dhc/dhcandroid/datastore/PreferencesName.kt
+++ b/data/src/main/kotlin/com/dhc/dhcandroid/datastore/PreferencesName.kt
@@ -1,0 +1,5 @@
+package com.dhc.dhcandroid.datastore
+
+object PreferencesName {
+    const val SAMPLE = "sample_preferences"
+}

--- a/data/src/main/kotlin/com/dhc/dhcandroid/datastore/PreferencesSerializer.kt
+++ b/data/src/main/kotlin/com/dhc/dhcandroid/datastore/PreferencesSerializer.kt
@@ -7,7 +7,7 @@ import com.google.protobuf.InvalidProtocolBufferException
 import java.io.InputStream
 import java.io.OutputStream
 
-class SamplePreferencesSerializer : Serializer<SamplePreferences> {
+class PreferencesSerializer : Serializer<SamplePreferences> {
     override val defaultValue: SamplePreferences = SamplePreferences.getDefaultInstance()
 
     override suspend fun readFrom(input: InputStream): SamplePreferences {

--- a/data/src/main/kotlin/com/dhc/dhcandroid/datastore/SamplePreferencesSerializer.kt
+++ b/data/src/main/kotlin/com/dhc/dhcandroid/datastore/SamplePreferencesSerializer.kt
@@ -1,0 +1,22 @@
+package com.dhc.dhcandroid.datastore
+
+import androidx.datastore.core.CorruptionException
+import androidx.datastore.core.Serializer
+import com.dhc.data.SamplePreferences
+import com.google.protobuf.InvalidProtocolBufferException
+import java.io.InputStream
+import java.io.OutputStream
+
+class SamplePreferencesSerializer : Serializer<SamplePreferences> {
+    override val defaultValue: SamplePreferences = SamplePreferences.getDefaultInstance()
+
+    override suspend fun readFrom(input: InputStream): SamplePreferences {
+        return try {
+            SamplePreferences.parseFrom(input)
+        } catch (exception: InvalidProtocolBufferException) {
+            throw CorruptionException("Cannot read proto", exception)
+        }
+    }
+
+    override suspend fun writeTo(t: SamplePreferences, output: OutputStream) = t.writeTo(output)
+}

--- a/data/src/main/kotlin/com/dhc/dhcandroid/di/DatastoreModule.kt
+++ b/data/src/main/kotlin/com/dhc/dhcandroid/di/DatastoreModule.kt
@@ -6,7 +6,7 @@ import androidx.datastore.core.DataStoreFactory
 import androidx.datastore.dataStoreFile
 import com.dhc.data.SamplePreferences
 import com.dhc.dhcandroid.datastore.PreferencesName
-import com.dhc.dhcandroid.datastore.SamplePreferencesSerializer
+import com.dhc.dhcandroid.datastore.PreferencesSerializer
 import dagger.Module
 import dagger.Provides
 import dagger.hilt.InstallIn
@@ -19,15 +19,15 @@ import javax.inject.Singleton
 internal object DatastoreModule {
     @Provides
     @Singleton
-    fun provideSamplePreferencesSerializer(): SamplePreferencesSerializer {
-        return SamplePreferencesSerializer()
+    fun providePreferencesSerializer(): PreferencesSerializer {
+        return PreferencesSerializer()
     }
 
     @Provides
     @Singleton
     fun provideSampleDatastore(
         @ApplicationContext context: Context,
-        serializer: SamplePreferencesSerializer,
+        serializer: PreferencesSerializer,
     ): DataStore<SamplePreferences> =
         DataStoreFactory.create(
             serializer = serializer,

--- a/data/src/main/kotlin/com/dhc/dhcandroid/di/DatastoreModule.kt
+++ b/data/src/main/kotlin/com/dhc/dhcandroid/di/DatastoreModule.kt
@@ -1,0 +1,36 @@
+package com.dhc.dhcandroid.di
+
+import android.content.Context
+import androidx.datastore.core.DataStore
+import androidx.datastore.core.DataStoreFactory
+import androidx.datastore.dataStoreFile
+import com.dhc.data.SamplePreferences
+import com.dhc.dhcandroid.datastore.PreferencesName
+import com.dhc.dhcandroid.datastore.SamplePreferencesSerializer
+import dagger.Module
+import dagger.Provides
+import dagger.hilt.InstallIn
+import dagger.hilt.android.qualifiers.ApplicationContext
+import dagger.hilt.components.SingletonComponent
+import javax.inject.Singleton
+
+@Module
+@InstallIn(SingletonComponent::class)
+internal object DatastoreModule {
+    @Provides
+    @Singleton
+    fun provideSamplePreferencesSerializer(): SamplePreferencesSerializer {
+        return SamplePreferencesSerializer()
+    }
+
+    @Provides
+    @Singleton
+    fun provideSampleDatastore(
+        @ApplicationContext context: Context,
+        serializer: SamplePreferencesSerializer,
+    ): DataStore<SamplePreferences> =
+        DataStoreFactory.create(
+            serializer = serializer,
+            produceFile = { context.dataStoreFile("${PreferencesName.SAMPLE}.pb") },
+        )
+}

--- a/data/src/main/proto/sample_preferences.proto
+++ b/data/src/main/proto/sample_preferences.proto
@@ -1,0 +1,16 @@
+syntax = "proto3";
+
+option java_package = "com.dhc.data";
+option java_multiple_files = true;
+
+message SamplePreferences {
+  bool hide_completed = 1;
+  string name = 2;
+  int32 age = 3;
+  repeated string hobbies = 4;
+  enum SortOrder {
+    BY_NAME = 0;
+    BY_DATE = 1;
+  }
+  SortOrder sort_order = 5;
+}

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -17,6 +17,12 @@ okhttp = "4.12.0"
 
 detekt = "1.22.0"
 
+#proto datastore
+protobuf = "0.9.5"
+proto-datastore = "1.1.6"
+protobuf-javalite = "3.25.5"
+
+
 # 프로젝트 설정
 targetSdk = "35"
 versionCode = "1"
@@ -64,6 +70,10 @@ okhttp = { module = "com.squareup.okhttp3:okhttp" }
 okhttp-logging-interceptor = { module = "com.squareup.okhttp3:logging-interceptor", version.ref = "okhttp" }
 retrofit = { group = "com.squareup.retrofit2", name = "retrofit", version.ref = "retrofit" }
 
+# proto datastore
+protobuf = { group = "androidx.datastore", name = "datastore", version.ref = "proto-datastore" }
+protobuf-javalite = { group = "com.google.protobuf", name = "protobuf-javalite", version.ref = "protobuf-javalite" }
+
 [bundles]
 hilt = [
     "hilt-navigation",
@@ -96,6 +106,11 @@ flipper = [
     "flipper-network",
 ]
 
+proto-datastore = [
+    "protobuf",
+    "protobuf-javalite",
+]
+
 
 [plugins]
 android-application = { id = "com.android.application", version.ref = "agp" }
@@ -106,3 +121,4 @@ dagger-hilt = { id = "com.google.dagger.hilt.android", version.ref = "dagger-hil
 kotlin-kapt = { id = "org.jetbrains.kotlin.kapt", version.ref = "kotlin" }
 jetbrains-kotlin-jvm = { id = "org.jetbrains.kotlin.jvm", version.ref = "kotlin" }
 android-library = { id = "com.android.library", version.ref = "agp" }
+protobuf = { id = "com.google.protobuf", version.ref = "protobuf" }


### PR DESCRIPTION
## 개요
🔑**이슈 링크** : https://github.com/mash-up-kr/DHC-Android/issues/50


## 💻작업 내용  
- proto datastore 의존성 추가
- Serializer 및 Datastore 파일 생성 샘플코드 작성 


## 🗣️To Reviwers  
- 찡끗


## 👾시연 화면 (option)  
- 빌드성공 확인하였습니다.

## Close 
close #50
