### PR TITLE
[#63] detekt 자동포매팅 적용

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -17,3 +17,8 @@ dependencies {
     androidTestImplementation(libs.androidx.junit)
     androidTestImplementation(libs.androidx.espresso.core)
 }
+
+detekt {
+    buildUponDefaultConfig = true
+    autoCorrect = true
+}

--- a/app/src/main/java/com/dhc/dhcandroid/MainActivity.kt
+++ b/app/src/main/java/com/dhc/dhcandroid/MainActivity.kt
@@ -4,8 +4,8 @@ import android.os.Bundle
 import androidx.activity.ComponentActivity
 import androidx.activity.compose.setContent
 import androidx.activity.enableEdgeToEdge
-import com.dhc.sample.home.HomeRoute
 import com.dhc.dhcandroid.ui.theme.DHCAndroidTheme
+import com.dhc.sample.home.HomeRoute
 import dagger.hilt.android.AndroidEntryPoint
 
 @AndroidEntryPoint

--- a/config/detekt/detekt.yml
+++ b/config/detekt/detekt.yml
@@ -127,7 +127,7 @@ complexity:
     threshold: 600
   LongMethod:
     active: true
-    threshold: 60
+    threshold: 150
   LongParameterList:
     active: true
     functionThreshold: 6


### PR DESCRIPTION
## 개요
🔑**이슈 링크** : https://github.com/mash-up-kr/DHC-Android/issues/63


## 💻작업 내용  
- detekt 자동으로 포매팅 하는 옵션 추가하였습니다.
- LongMethod (하나의 함수가 가질 수 있는 최대 길이에 대한 Lint 조건) 이 현재 60줄이고, 이거 너무 타이트해보여서 150줄로 수정하였습니다!


## 🗣️To Reviwers  
- 혹시 더 수정하고 싶은 규칙 있으면 알려주세용
- 자동포매팅은 따로 옵션 줄건 없고, `./gradlew detekt` 실행하면 자동으로 수정됩니당~ 
- 근데 다 고칠 수 있는거만 고쳐주는거라서 전부다 수정해주진 않으니 참고해주세용 (예를들어 트레일링 콤마는 자동으로 달아주고, 공백같은건 자동으로 제거해줌) 


## Close 
close #63
