### PR TITLE
[#67] SplashScreen 대충 개발

### DIFF
--- a/app/src/main/java/com/dhc/dhcandroid/navigation/DhcApp.kt
+++ b/app/src/main/java/com/dhc/dhcandroid/navigation/DhcApp.kt
@@ -10,7 +10,7 @@ import androidx.compose.ui.Modifier
 
 @Composable
 fun DhcApp() {
-    val startDestination = DhcRoute.INTRO
+    val startDestination = DhcRoute.SPLASH
     val navController = rememberDhcNavController(startDestination)
 
     Scaffold(

--- a/app/src/main/java/com/dhc/dhcandroid/navigation/DhcNavHost.kt
+++ b/app/src/main/java/com/dhc/dhcandroid/navigation/DhcNavHost.kt
@@ -10,6 +10,7 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.navigation.compose.NavHost
 import androidx.navigation.compose.composable
+import com.dhc.intro.splash.SplashRoute
 
 @Composable
 fun DhcNavHost(
@@ -22,6 +23,14 @@ fun DhcNavHost(
         navController = navController.controller,
         startDestination = startDestination.route,
     ) {
+        composable(DhcRoute.SPLASH.route) {
+            SplashRoute(
+                navigateToNextScreen = {
+                    navController.navigateToIntroFromSplash()
+                }
+            )
+        }
+
         composable(DhcRoute.INTRO.route) {
             // 아래 내용은 예시
             Column(

--- a/app/src/main/java/com/dhc/dhcandroid/navigation/DhcRoute.kt
+++ b/app/src/main/java/com/dhc/dhcandroid/navigation/DhcRoute.kt
@@ -4,6 +4,13 @@ enum class DhcRoute(
     val route: String,
     val screenConfig: ScreenConfig,
 ) {
+    SPLASH(
+        route = "splash",
+        screenConfig = ScreenConfig(
+            topBarState = DhcTopBarState.None,
+            bottomBarState = DhcBottomBarState.None,
+        ),
+    ),
     INTRO(
         route = "intro",
         screenConfig = ScreenConfig(

--- a/app/src/main/java/com/dhc/dhcandroid/navigation/NavigationExtension.kt
+++ b/app/src/main/java/com/dhc/dhcandroid/navigation/NavigationExtension.kt
@@ -1,5 +1,13 @@
 package com.dhc.dhcandroid.navigation
 
+fun DhcNavHostController.navigateToIntroFromSplash() {
+    navigateTo(DhcRoute.INTRO) {
+        popUpTo(DhcRoute.SPLASH.route) {
+            inclusive = true
+        }
+    }
+}
+
 fun DhcNavHostController.navigateToHomeFromIntro() {
     navigateTo(DhcRoute.MAIN_HOME) {
         popUpTo(DhcRoute.INTRO.route) {

--- a/build-logic/convention/src/main/kotlin/AndroidApplicationPlugin.kt
+++ b/build-logic/convention/src/main/kotlin/AndroidApplicationPlugin.kt
@@ -34,6 +34,7 @@ class AndroidApplicationPlugin : Plugin<Project> {
             }
 
             dependencies {
+                implementation(project(":presentation:intro"))
                 implementation(project(":presentation:sample"))
                 implementation(project(":data"))
                 implementation(project(":core:designsystem"))

--- a/presentation/intro/src/main/java/com/dhc/intro/splash/SplashContract.kt
+++ b/presentation/intro/src/main/java/com/dhc/intro/splash/SplashContract.kt
@@ -1,0 +1,28 @@
+package com.dhc.intro.splash
+
+import com.dhc.presentation.mvi.UiEvent
+import com.dhc.presentation.mvi.UiSideEffect
+import com.dhc.presentation.mvi.UiState
+
+class SplashContract {
+
+    /**
+     * 현재 화면에 필요한 상태들을 모아둔다.
+     */
+    data class State(
+        val isSplashFinished: Boolean = false,
+    ) : UiState
+
+
+    /**
+     * 액션 정의
+     */
+    sealed interface Event : UiEvent {
+        data object SplashFinished : Event
+    }
+
+    /**
+     * SideEffect로 발생되는 이벤트를 정의
+     */
+    sealed interface SideEffect : UiSideEffect
+}

--- a/presentation/intro/src/main/java/com/dhc/intro/splash/SplashRoute.kt
+++ b/presentation/intro/src/main/java/com/dhc/intro/splash/SplashRoute.kt
@@ -1,0 +1,22 @@
+package com.dhc.intro.splash
+
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.hilt.navigation.compose.hiltViewModel
+
+@Composable
+fun SplashRoute(
+    navigateToNextScreen: () -> Unit,
+    viewModel: SplashViewModel = hiltViewModel(),
+) {
+    val state by viewModel.state.collectAsState()
+    LaunchedEffect(state.isSplashFinished) {
+        if (state.isSplashFinished) {
+            navigateToNextScreen()
+        }
+    }
+
+    SplashScreen()
+}

--- a/presentation/intro/src/main/java/com/dhc/intro/splash/SplashScreen.kt
+++ b/presentation/intro/src/main/java/com/dhc/intro/splash/SplashScreen.kt
@@ -1,14 +1,34 @@
 package com.dhc.intro.splash
 
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
 
 @Composable
 fun SplashScreen() {
-
+    Box(
+        modifier = Modifier.fillMaxSize(),
+        contentAlignment = Alignment.Center,
+    ) {
+        // TODO : Lottie 로 변경
+        Box(
+            modifier = Modifier
+                .padding(bottom = 42.dp)
+                .size(204.dp)
+                .background(Color.Cyan),
+        )
+    }
 }
 
-@Preview
+@Preview(showBackground = true)
 @Composable
 private fun SplashScreenPreview() {
     SplashScreen()

--- a/presentation/intro/src/main/java/com/dhc/intro/splash/SplashViewModel.kt
+++ b/presentation/intro/src/main/java/com/dhc/intro/splash/SplashViewModel.kt
@@ -1,0 +1,43 @@
+package com.dhc.intro.splash
+
+import androidx.lifecycle.viewModelScope
+import com.dhc.presentation.mvi.BaseViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import com.dhc.intro.splash.SplashContract.State
+import com.dhc.intro.splash.SplashContract.Event
+import com.dhc.intro.splash.SplashContract.SideEffect
+import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+@HiltViewModel
+class SplashViewModel @Inject constructor(
+) : BaseViewModel<State, Event, SideEffect>() {
+
+    init {
+        waitSplashTimeAndFinished()
+    }
+
+    override fun createInitialState(): State {
+        return State()
+    }
+
+    override suspend fun handleEvent(event: Event) {
+        when (event) {
+            Event.SplashFinished -> {
+                reduce { copy(isSplashFinished = true) }
+            }
+        }
+    }
+
+    private fun waitSplashTimeAndFinished() {
+        viewModelScope.launch {
+            delay(SPLASH_TIME)
+            handleEvent(Event.SplashFinished)
+        }
+    }
+
+    companion object {
+        private const val SPLASH_TIME = 1500L // 2 seconds
+    }
+}


### PR DESCRIPTION
## 개요
🔑**이슈 링크** : https://github.com/mash-up-kr/DHC-Android/issues/67

## 💻작업 내용  
<img width="821" alt="Image" src="https://github.com/user-attachments/assets/7bca9b5d-7e78-4bcb-aa54-b3278567be40" />

- SplashScreen, SplashViewModel, SplashRoute, SplashContract 개발
- SplashScreen 이 먼저 나오도록 하고, 1.5초 지나면 인트로화면으로 이동하도록 수정했어용
- lottie 자리는 비워두었어용

## 🗣️To Reviwers  
- 찡끗


## 👾시연 화면 (option)  

|시연영상|  
|-|
|<video src="https://github.com/user-attachments/assets/151cce64-0b0f-4a85-80f6-1eb352172795" />|


## Close 
close #67
