### PR TITLE
[#118] DhcSpinner 에서 DhcSpinnerItem 으로 공통로직 분리하기

### DIFF
--- a/core/designsystem/src/main/kotlin/com/dhc/designsystem/spinner/DhcDaySpinner.kt
+++ b/core/designsystem/src/main/kotlin/com/dhc/designsystem/spinner/DhcDaySpinner.kt
@@ -3,8 +3,6 @@ package com.dhc.designsystem.spinner
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
@@ -22,9 +20,7 @@ import com.dhc.common.CalendarUtil
 import com.dhc.designsystem.DhcTheme
 import com.dhc.designsystem.LocalDhcColors
 import com.dhc.designsystem.R
-import com.dhc.designsystem.spinner.common.DhcItemSpinnerBackground
-import com.dhc.designsystem.spinner.common.DhcItemSpinnerContent
-import com.dhc.designsystem.spinner.common.DhcSpinner
+import com.dhc.designsystem.spinner.common.DhcSpinnerItem
 
 @Composable
 fun DhcDaySpinner(
@@ -61,80 +57,32 @@ fun DhcDaySpinner(
             .padding(horizontal = 16.dp),
         horizontalArrangement = Arrangement.spacedBy(23.dp),
     ) {
-        DhcSpinner(
+        DhcSpinnerItem(
             itemList = yearList,
             visibleItemsCount = visibleItemsCount,
             itemHeightDp = itemHeightDp,
+            initialItem = initialYear,
             onValueChanged = { currentYear = it },
+            itemTextCreator = { stringResource(R.string.d_year, it) },
             modifier = Modifier.weight(2f),
-            initialIndex = yearList.indexOf(initialYear).coerceAtLeast(0),
-            itemBackground = { isFocused ->
-                DhcItemSpinnerBackground(
-                    isFocused = isFocused,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(itemHeightDp),
-                )
-            },
-            itemContent = { item, isFocused ->
-                DhcItemSpinnerContent(
-                    text = stringResource(R.string.d_year, item),
-                    isFocused = isFocused,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(itemHeightDp),
-                )
-            }
         )
-        DhcSpinner(
+        DhcSpinnerItem(
             itemList = monthList,
             visibleItemsCount = visibleItemsCount,
             itemHeightDp = itemHeightDp,
+            initialItem = initialMonth,
             onValueChanged = { currentMonth = it },
+            itemTextCreator = { stringResource(R.string.d_month, it) },
             modifier = Modifier.weight(1f),
-            initialIndex = monthList.indexOf(initialMonth).coerceAtLeast(0),
-            itemBackground = { isFocused ->
-                DhcItemSpinnerBackground(
-                    isFocused = isFocused,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(itemHeightDp),
-                )
-            },
-            itemContent = { item, isFocused ->
-                DhcItemSpinnerContent(
-                    text = stringResource(R.string.d_month, item),
-                    isFocused = isFocused,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(itemHeightDp),
-                )
-            }
         )
-        DhcSpinner(
+        DhcSpinnerItem(
             itemList = dayList,
             visibleItemsCount = visibleItemsCount,
             itemHeightDp = itemHeightDp,
+            initialItem = initialDay,
             onValueChanged = { currentDay = it },
+            itemTextCreator = { stringResource(R.string.d_day, it) },
             modifier = Modifier.weight(1f),
-            initialIndex = dayList.indexOf(initialDay).coerceAtLeast(0),
-            itemBackground = { isFocused ->
-                DhcItemSpinnerBackground(
-                    isFocused = isFocused,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(itemHeightDp),
-                )
-            },
-            itemContent = { item, isFocused ->
-                DhcItemSpinnerContent(
-                    text = stringResource(R.string.d_day, item),
-                    isFocused = isFocused,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(itemHeightDp),
-                )
-            }
         )
     }
 }

--- a/core/designsystem/src/main/kotlin/com/dhc/designsystem/spinner/DhcTimeSpinner.kt
+++ b/core/designsystem/src/main/kotlin/com/dhc/designsystem/spinner/DhcTimeSpinner.kt
@@ -24,6 +24,7 @@ import com.dhc.designsystem.R
 import com.dhc.designsystem.spinner.common.DhcItemSpinnerBackground
 import com.dhc.designsystem.spinner.common.DhcItemSpinnerContent
 import com.dhc.designsystem.spinner.common.DhcSpinner
+import com.dhc.designsystem.spinner.common.DhcSpinnerItem
 import com.dhc.designsystem.spinner.model.TimeType
 
 @Composable
@@ -55,80 +56,32 @@ fun DhcTimeSpinner(
             .padding(horizontal = 16.dp),
         horizontalArrangement = Arrangement.spacedBy(23.dp),
     ) {
-        DhcSpinner(
+        DhcSpinnerItem(
             itemList = timeTypeList,
             visibleItemsCount = visibleItemsCount,
             itemHeightDp = itemHeightDp,
+            initialItem = initialTimeType,
             onValueChanged = { currentTimeType = it },
+            itemTextCreator = { it.text },
             modifier = Modifier.weight(2f),
-            initialIndex = timeTypeList.indexOf(initialTimeType),
-            itemBackground = { isFocused ->
-                DhcItemSpinnerBackground(
-                    isFocused = isFocused,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(itemHeightDp),
-                )
-            },
-            itemContent = { item, isFocused ->
-                DhcItemSpinnerContent(
-                    text = item.text,
-                    isFocused = isFocused,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(itemHeightDp),
-                )
-            }
         )
-        DhcSpinner(
+        DhcSpinnerItem(
             itemList = timeList,
             visibleItemsCount = visibleItemsCount,
             itemHeightDp = itemHeightDp,
+            initialItem = initialTime,
             onValueChanged = { currentTime = it },
+            itemTextCreator = { stringResource(R.string.d_hour, it) },
             modifier = Modifier.weight(1f),
-            initialIndex = timeList.indexOf(initialTime).coerceAtLeast(0),
-            itemBackground = { isFocused ->
-                DhcItemSpinnerBackground(
-                    isFocused = isFocused,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(itemHeightDp),
-                )
-            },
-            itemContent = { item, isFocused ->
-                DhcItemSpinnerContent(
-                    text = stringResource(R.string.d_hour, item),
-                    isFocused = isFocused,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(itemHeightDp),
-                )
-            }
         )
-        DhcSpinner(
+        DhcSpinnerItem(
             itemList = minuteList,
             visibleItemsCount = visibleItemsCount,
             itemHeightDp = itemHeightDp,
+            initialItem = initialMinute,
             onValueChanged = { currentMinute = it },
+            itemTextCreator = { stringResource(R.string.d_minute, it) },
             modifier = Modifier.weight(1f),
-            initialIndex = minuteList.indexOf(initialMinute).coerceAtLeast(0),
-            itemBackground = { isFocused ->
-                DhcItemSpinnerBackground(
-                    isFocused = isFocused,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(itemHeightDp),
-                )
-            },
-            itemContent = { item, isFocused ->
-                DhcItemSpinnerContent(
-                    text = stringResource(R.string.d_minute, item),
-                    isFocused = isFocused,
-                    modifier = Modifier
-                        .fillMaxWidth()
-                        .height(itemHeightDp),
-                )
-            }
         )
     }
 }

--- a/core/designsystem/src/main/kotlin/com/dhc/designsystem/spinner/common/DhcSpinnerItem.kt
+++ b/core/designsystem/src/main/kotlin/com/dhc/designsystem/spinner/common/DhcSpinnerItem.kt
@@ -1,0 +1,63 @@
+package com.dhc.designsystem.spinner.common
+
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.dhc.designsystem.DhcTheme
+
+@Composable
+fun <T : Any> DhcSpinnerItem(
+    itemList: Collection<T>,
+    visibleItemsCount: Int,
+    itemHeightDp: Dp,
+    initialItem: T,
+    onValueChanged: (T) -> Unit,
+    itemTextCreator: @Composable (T) -> String,
+    modifier: Modifier = Modifier,
+) {
+    DhcSpinner(
+        itemList = itemList,
+        visibleItemsCount = visibleItemsCount,
+        itemHeightDp = itemHeightDp,
+        onValueChanged = onValueChanged,
+        modifier = modifier,
+        initialIndex = itemList.indexOf(initialItem).coerceAtLeast(0),
+        itemBackground = { isFocused ->
+            DhcItemSpinnerBackground(
+                isFocused = isFocused,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(itemHeightDp),
+            )
+        },
+        itemContent = { item, isFocused ->
+            DhcItemSpinnerContent(
+                text = itemTextCreator(item),
+                isFocused = isFocused,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(itemHeightDp),
+            )
+        }
+    )
+}
+
+@Preview
+@Composable
+private fun DhcSpinnerItemPreview() {
+    DhcTheme {
+        DhcSpinnerItem(
+            itemList = (1900..2025).toList(),
+            visibleItemsCount = 5,
+            itemHeightDp = 48.dp,
+            initialItem = 2000,
+            onValueChanged = {},
+            itemTextCreator = { it.toString() },
+            modifier = Modifier.fillMaxWidth(),
+        )
+    }
+}


### PR DESCRIPTION
## 개요
🔑**이슈 링크** : https://github.com/mash-up-kr/DHC-Android/issues/118


## 💻작업 내용  
- 호현이형 말과 같이 공통적으로 사용되는 부분을 DhcSpinnerItem 으로 별도로 분리해보았습니다
- 진짜 보기 편해진 것 같아용 👍 👍 


## 🗣️To Reviwers  
- 정상빌드 및 동작 확인했습니당

## Close 
close #118 
