### PR TITLE
[#124] '}' 없어서 github action error 나던 것 수정

### DIFF
--- a/.github/workflows/build-debug-check.yaml
+++ b/.github/workflows/build-debug-check.yaml
@@ -18,7 +18,7 @@ jobs:
 
       - name: Putting Google Json
         env:
-          GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }
+          GOOGLE_SERVICES_JSON: ${{ secrets.GOOGLE_SERVICES_JSON }}
         run: |
           mkdir /home/runner/work/DHC-Android/DHC-Android/app
           echo "$GOOGLE_SERVICES_JSON" > /home/runner/work/DHC-Android/DHC-Android/app/google-services.json


### PR DESCRIPTION
## 개요
🔑**이슈 링크** : https://github.com/mash-up-kr/DHC-Android/issues/124


## 💻작업 내용  
- '}' 없어서 github action error 나던 것 수정


## 🗣️To Reviwers  
- 찡끗


## 👾시연 화면 (option)  

|기능A 구현|기능B 구현|  
|:---|---|
|||


## Close 
close #124 
