### PR TITLE
[#113] FlippableBox, DhcFortuneCard 추가

### DIFF
--- a/core/designsystem/src/main/kotlin/com/dhc/designsystem/Typography.kt
+++ b/core/designsystem/src/main/kotlin/com/dhc/designsystem/Typography.kt
@@ -48,7 +48,7 @@ object LineHeightToken {
 }
 
 object DhcTypoTokens {
-    private val typoFontFamily = FontFamily(
+    val typoFontFamily = FontFamily(
         Font(R.font.wantedsans_bold, FontWeight.W700),
         Font(R.font.wantedsans_semibold, FontWeight.W600),
         Font(R.font.wantedsans_medium, FontWeight.W500),

--- a/core/designsystem/src/main/kotlin/com/dhc/designsystem/fortunecard/DhcFortuneCard.kt
+++ b/core/designsystem/src/main/kotlin/com/dhc/designsystem/fortunecard/DhcFortuneCard.kt
@@ -65,6 +65,7 @@ fun DhcFortuneCard(
             style = DhcTypoTokens.Body7,
             textAlign = TextAlign.Center,
         )
+        // Todo : 카드 비율이 어떻게 될지 아직 몰라서 임시로 Spacer 가 들어가있습니다. 추후 정책 확정되면 제거 될 예정입니다.
         Spacer(modifier = Modifier.height(119.dp))
         Text(
             modifier = Modifier.padding(bottom = 8.dp),

--- a/core/designsystem/src/main/kotlin/com/dhc/designsystem/fortunecard/DhcFortuneCard.kt
+++ b/core/designsystem/src/main/kotlin/com/dhc/designsystem/fortunecard/DhcFortuneCard.kt
@@ -1,0 +1,115 @@
+package com.dhc.designsystem.fortunecard
+
+import androidx.compose.foundation.BorderStroke
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.clip
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import androidx.compose.ui.unit.dp
+import androidx.compose.ui.unit.sp
+import com.dhc.designsystem.AccentColor
+import com.dhc.designsystem.DhcTheme
+import com.dhc.designsystem.DhcTypoTokens
+import com.dhc.designsystem.DhcTypoTokens.typoFontFamily
+import com.dhc.designsystem.GradientColor
+import com.dhc.designsystem.SurfaceColor
+
+@Composable
+fun DhcFortuneCard(
+    title: String,
+    description: String,
+    modifier: Modifier = Modifier,
+) {
+    Column(
+        modifier = modifier
+            .clip(RoundedCornerShape(12.dp))
+            .background(
+                color = SurfaceColor.neutral700,
+                shape = RoundedCornerShape(12.dp),
+            )
+            .border(
+                border = BorderStroke(
+                    width = 1.dp,
+                    brush = Brush.verticalGradient(
+                        colors = listOf(
+                            AccentColor.violet300,
+                            SurfaceColor.neutral600,
+                        ),
+                    ),
+                ),
+                shape = RoundedCornerShape(12.dp),
+            )
+            .padding(vertical = 20.dp, horizontal = 24.dp),
+        horizontalAlignment = Alignment.CenterHorizontally,
+    ) {
+        Text(
+            modifier = Modifier.padding(bottom = 8.dp),
+            text = title,
+            color = SurfaceColor.neutral200,
+            style = DhcTypoTokens.Body7,
+            textAlign = TextAlign.Center,
+        )
+        Spacer(modifier = Modifier.height(119.dp))
+        Text(
+            modifier = Modifier.padding(bottom = 8.dp),
+            text = description,
+            style = TextStyle(
+                fontFamily = typoFontFamily,
+                fontWeight = FontWeight.W600,
+                fontSize = 14.sp,
+                lineHeight = 20.sp,
+                brush = GradientColor.textGradient02,
+            ),
+            textAlign = TextAlign.Center,
+        )
+    }
+}
+
+private class DhcFortuneCardPreviewProvider : PreviewParameterProvider<DhcFortuneCardPreviewProvider.Parameter> {
+    override val values = sequenceOf(
+        Parameter(
+            title = "오늘의 운세 카드",
+            description = "'한템포 쉬어가기'",
+        ),
+        Parameter(
+            title = "???",
+            description = "",
+        ),
+    )
+
+    data class Parameter(
+        val title: String,
+        val description: String,
+    )
+}
+
+@Preview
+@Composable
+private fun DhcFortuneCardPreview(
+    @PreviewParameter(DhcFortuneCardPreviewProvider::class)
+    parameter: DhcFortuneCardPreviewProvider.Parameter,
+) {
+    DhcTheme {
+        DhcFortuneCard(
+            title = parameter.title,
+            description = parameter.description,
+            modifier = Modifier.width(143.dp),
+        )
+    }
+}

--- a/core/designsystem/src/main/kotlin/com/dhc/designsystem/fortunecard/FlippableBox.kt
+++ b/core/designsystem/src/main/kotlin/com/dhc/designsystem/fortunecard/FlippableBox.kt
@@ -1,0 +1,79 @@
+package com.dhc.designsystem.fortunecard
+
+import androidx.compose.animation.core.animateFloatAsState
+import androidx.compose.foundation.clickable
+import androidx.compose.foundation.gestures.detectHorizontalDragGestures
+import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.layout.Box
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.derivedStateOf
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableFloatStateOf
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.input.pointer.pointerInput
+
+@Composable
+fun FlippableBox(
+    onFlipEnd: () -> Unit,
+    frontScreen: @Composable () -> Unit,
+    backScreen: @Composable () -> Unit,
+    modifier: Modifier = Modifier,
+    minRotationAngle: Float = 0f,
+    maxRotationAngle: Float = 180f,
+    flipThreshold: Float = 90f,
+    initialRotationZ: Float = 0f,
+) {
+    var canRotate by remember { mutableStateOf(true) }
+    var rotationAngleState by remember { mutableFloatStateOf(0f) }
+    val animatedRotationAngleState by animateFloatAsState(targetValue = rotationAngleState, label = "")
+    val isFront by remember(animatedRotationAngleState) {
+        derivedStateOf {
+            val angle = animatedRotationAngleState % 360
+            angle <= 90f || angle >= 270f
+        }
+    }
+    LaunchedEffect(canRotate) {
+        if (canRotate.not()) { onFlipEnd() }
+    }
+
+    Box(
+        modifier = modifier
+            .clickable(
+                indication = null,
+                interactionSource = remember { MutableInteractionSource() },
+                onClick = {
+                    if (canRotate) {
+                        rotationAngleState = (rotationAngleState + maxRotationAngle)
+                            .coerceIn(minRotationAngle, maxRotationAngle)
+                            .also { canRotate = false }
+                    }
+                }
+            )
+            .pointerInput(Unit) {
+                detectHorizontalDragGestures(
+                    onDragEnd = {
+                        rotationAngleState = (if (rotationAngleState < flipThreshold) 0f else 180f)
+                            .also { if (it == 180f) canRotate = false }
+                    },
+                    onHorizontalDrag = { _, dragAmount ->
+                        if (canRotate) {
+                            rotationAngleState = (rotationAngleState + dragAmount)
+                                .coerceIn(minRotationAngle, maxRotationAngle)
+                        }
+                    },
+                )
+            }
+            .graphicsLayer {
+                rotationY = animatedRotationAngleState + if (isFront) 0f else 180f
+                rotationZ = initialRotationZ - (initialRotationZ * (animatedRotationAngleState / maxRotationAngle))
+                cameraDistance = 15f
+            }
+    ) {
+        if (isFront) frontScreen() else backScreen()
+    }
+}


### PR DESCRIPTION
## 개요
🔑**이슈 링크** : https://github.com/mash-up-kr/DHC-Android/issues/113


## 💻작업 내용  
- 뒤집기 가능한 FlippableBox 와 카드 디자인의 DhcFortuneCard 를 개발해봤어용
- 드래그로 뒤집기도 가능하고, 클릭으로 뒤집기도 가능해요
- 뒤집고나면 되돌릴 수 없어용

## 🗣️To Reviwers  
- 이것저것 지원 가능하게 파라미터를 넣긴 했는데, 필요한거 더 보이면 공유해주시면 개발할게용

## 👾시연 화면 (option)  

|기능 구현|  
|---|
|<video src="https://github.com/user-attachments/assets/7dc354b1-b57e-40a9-acd5-7f9671bd3a15"/>|


## Close 
close #113 
