### PR TITLE
[#133] 디자인 시스템 컴포넌트 - 금전운 점수, 더보기 버튼

### DIFF
--- a/core/designsystem/src/main/kotlin/com/dhc/designsystem/FortuneCore.kt
+++ b/core/designsystem/src/main/kotlin/com/dhc/designsystem/FortuneCore.kt
@@ -1,0 +1,64 @@
+package com.dhc.designsystem
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.border
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.shape.CircleShape
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun FortuneCore(
+    fortuneScore: Int,
+) {
+    val color = LocalDhcColors.current
+    Column(
+        modifier = Modifier
+            .size(80.dp)
+            .background(shape = CircleShape, color = Color.Transparent)
+            .border(
+                width = 1.dp,
+                brush = Brush.verticalGradient(
+                    colors = listOf(AccentColor.violet400.copy(alpha = 0.28f), SurfaceColor.neutral200.copy(alpha = 0.28f))),
+                shape = CircleShape
+            ),
+        verticalArrangement = Arrangement.Center,
+        horizontalAlignment = Alignment.CenterHorizontally
+    ) {
+        Text(
+            text = stringResource(id = R.string.money_fortune),
+            style = DhcTypoTokens.Body6,
+            color = SurfaceColor.neutral300,
+            textAlign = TextAlign.Center,
+        )
+
+        Text(
+            text = "${fortuneScore}점",
+            style = DhcTypoTokens.TitleH3.copy(
+                brush = GradientColor.textGradient01
+            ),
+            textAlign = TextAlign.Center,
+        )
+
+    }
+}
+
+@Preview
+@Composable
+fun PreviewFortuneCore() {
+    DhcTheme {
+        FortuneCore(
+            fortuneScore = 35
+        )
+    }
+}

--- a/core/designsystem/src/main/kotlin/com/dhc/designsystem/FortuneCore.kt
+++ b/core/designsystem/src/main/kotlin/com/dhc/designsystem/FortuneCore.kt
@@ -23,10 +23,10 @@ import androidx.compose.ui.unit.dp
 @Composable
 fun FortuneCore(
     fortuneScore: Int,
+    modifier: Modifier = Modifier,
 ) {
     Column(
-        modifier = Modifier
-            .size(80.dp)
+        modifier = modifier
             .background(shape = CircleShape, color = Color.Transparent)
             .border(
                 width = 1.dp,
@@ -45,7 +45,7 @@ fun FortuneCore(
         )
 
         Text(
-            text = "${fortuneScore}점",
+            text = stringResource(R.string.d_score, fortuneScore),
             style = DhcTypoTokens.TitleH3.copy(
                 brush = GradientColor.textGradient01
             ),
@@ -60,7 +60,8 @@ fun FortuneCore(
 fun PreviewFortuneCore() {
     DhcTheme {
         FortuneCore(
-            fortuneScore = 35
+            fortuneScore = 35,
+            modifier = Modifier.size(80.dp)
         )
     }
 }

--- a/core/designsystem/src/main/kotlin/com/dhc/designsystem/FortuneCore.kt
+++ b/core/designsystem/src/main/kotlin/com/dhc/designsystem/FortuneCore.kt
@@ -17,11 +17,13 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 
+/**
+ * TODO - 홈 모듈로 이동
+ */
 @Composable
 fun FortuneCore(
     fortuneScore: Int,
 ) {
-    val color = LocalDhcColors.current
     Column(
         modifier = Modifier
             .size(80.dp)

--- a/core/designsystem/src/main/kotlin/com/dhc/designsystem/MoreButton.kt
+++ b/core/designsystem/src/main/kotlin/com/dhc/designsystem/MoreButton.kt
@@ -1,0 +1,52 @@
+package com.dhc.designsystem
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.Icon
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+
+@Composable
+fun MoreButton() {
+    Row(
+        modifier = Modifier.wrapContentSize()
+            .background(SurfaceColor.neutral700, RoundedCornerShape(99.dp))
+            .padding(start = 12.dp, end = 8.dp, top = 4.dp, bottom = 4.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.Center
+    ) {
+        Text(
+            text = stringResource(R.string.more),
+            style = DhcTypoTokens.Body6,
+            color = SurfaceColor.neutral300,
+        )
+        Spacer(modifier = Modifier.width(4.dp))
+        Icon(
+            modifier = Modifier.size(20.dp),
+            painter = painterResource(R.drawable.ico_arrow_right),
+            contentDescription = "more_button",
+            tint = SurfaceColor.neutral300,
+        )
+    }
+}
+
+@Composable
+@Preview
+fun PreviewMoreButton() {
+    DhcTheme {
+        MoreButton()
+    }
+}

--- a/core/designsystem/src/main/kotlin/com/dhc/designsystem/MoreButton.kt
+++ b/core/designsystem/src/main/kotlin/com/dhc/designsystem/MoreButton.kt
@@ -19,6 +19,9 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 
+/**
+ * TODO - 홈 모듈로 이동
+ */
 @Composable
 fun MoreButton() {
     Row(

--- a/core/designsystem/src/main/kotlin/com/dhc/designsystem/MoreButton.kt
+++ b/core/designsystem/src/main/kotlin/com/dhc/designsystem/MoreButton.kt
@@ -18,15 +18,18 @@ import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.dhc.common.FullRoundedCornerShape
 
 /**
  * TODO - 홈 모듈로 이동
  */
 @Composable
-fun MoreButton() {
+fun MoreButton(
+    modifier: Modifier = Modifier,
+) {
     Row(
-        modifier = Modifier.wrapContentSize()
-            .background(SurfaceColor.neutral700, RoundedCornerShape(99.dp))
+        modifier = modifier.wrapContentSize()
+            .background(SurfaceColor.neutral700, FullRoundedCornerShape)
             .padding(start = 12.dp, end = 8.dp, top = 4.dp, bottom = 4.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.Center
@@ -40,7 +43,7 @@ fun MoreButton() {
         Icon(
             modifier = Modifier.size(20.dp),
             painter = painterResource(R.drawable.ico_arrow_right),
-            contentDescription = "more_button",
+            contentDescription = "MoreButton",
             tint = SurfaceColor.neutral300,
         )
     }

--- a/core/designsystem/src/main/res/values/strings.xml
+++ b/core/designsystem/src/main/res/values/strings.xml
@@ -17,5 +17,7 @@
     <string name="btn_bottom_home">홈</string>
     <string name="btn_bottom_mission">미션 현황</string>
     <string name="btn_bottom_my_page">마이페이지</string>
+
+    <string name="money_fortune">금전운</string>
 </resources>
 

--- a/core/designsystem/src/main/res/values/strings.xml
+++ b/core/designsystem/src/main/res/values/strings.xml
@@ -19,5 +19,6 @@
     <string name="btn_bottom_my_page">마이페이지</string>
 
     <string name="money_fortune">금전운</string>
+    <string name="more">더보기</string>
 </resources>
 


### PR DESCRIPTION
## 개요
🔑**이슈 링크** : https://github.com/mash-up-kr/DHC-Android/issues/133


## 💻작업 내용  
 >작업한 내용을 구체적으로 작성해주세요.
- 금전운 코어와 더보기 버튼 구현완료~!
(짧아서 같이 올립니다..)


## 🗣️To Reviwers  
> 리뷰어들이 중점적으로 봤으면 하는 부분이나, 전달하고 싶은 사항에 대해 작성해주세요.
- 근데 둘다 홈화면에서만 사용해서... 홈모듈 머지후에 옮기려고 하는데 어때요??
- 금전운 코어는 뒤에 배경 투명이었음....!

## 👾시연 화면 (option)  

|기능A 구현|기능B 구현|  
|:---|---|
|<img width="197" alt="스크린샷 2025-06-13 오후 4 14 07" src="https://github.com/user-attachments/assets/9c3c89e9-74ca-4762-ba28-420d010dccba" />|<img width="355" alt="스크린샷 2025-06-13 오후 4 14 28" src="https://github.com/user-attachments/assets/48ede291-65da-4844-91d3-ad708f7fb174" />|

## Close 
close #133
