### PR TITLE
[#168] DhcTitle subtitle 과 title 의 가로범위가 동일하지 않은 이슈 수정

### DIFF
--- a/core/designsystem/src/main/kotlin/com/dhc/designsystem/title/DhcTitle.kt
+++ b/core/designsystem/src/main/kotlin/com/dhc/designsystem/title/DhcTitle.kt
@@ -2,6 +2,7 @@ package com.dhc.designsystem.title
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -21,8 +22,8 @@ import com.dhc.designsystem.SurfaceColor
 fun DhcTitle(
     title: String,
     textAlign: TextAlign,
-    subTitle: String? = null,
     modifier: Modifier = Modifier,
+    subTitle: String? = null,
 ) {
     Column(
         modifier = modifier,
@@ -34,6 +35,7 @@ fun DhcTitle(
             style = DhcTypoTokens.TitleH2,
             color = Color.White,
             textAlign = textAlign,
+            modifier = Modifier.fillMaxWidth(),
         )
         subTitle?.let { text ->
             Text(
@@ -41,6 +43,7 @@ fun DhcTitle(
                 style = DhcTypoTokens.Body3,
                 color = SurfaceColor.neutral200,
                 textAlign = textAlign,
+                modifier = Modifier.fillMaxWidth(),
             )
         }
     }


### PR DESCRIPTION
## 개요
🔑**이슈 링크** : https://github.com/mash-up-kr/DHC-Android/issues/168


## 💻작업 내용  
- DhcTitle 정렬기능 사용하면 내부 텍스트의 가로범위 때문에 의도와 다르게 노출되는 이슈가 있슴당

## 🗣️To Reviwers  
- ㅠㅠ

## 👾시연 화면 (option)  

|Before|After|  
|---|---|
|<img width="233" alt="스크린샷 2025-06-15 오후 5 36 44" src="https://github.com/user-attachments/assets/2a2a0bae-29c7-48aa-83a9-7357c12e5295" />|<img width="241" alt="스크린샷 2025-06-15 오후 5 35 52" src="https://github.com/user-attachments/assets/c11fb552-77fc-480c-8727-d1d377fbe88e" />|




## Close 
close #168 
