### PR TITLE
[#167] DhcTopBar 가 statusBar 영역까지 침범하는 이슈 수정

### DIFF
--- a/app/src/main/java/com/dhc/dhcandroid/navigation/DhcApp.kt
+++ b/app/src/main/java/com/dhc/dhcandroid/navigation/DhcApp.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.statusBarsPadding
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.State
@@ -30,6 +31,9 @@ fun DhcApp() {
             DhcTopBar(
                 state = currentScreenConfig.topBarState,
                 navigateUp = { navController.navigateUp() },
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .statusBarsPadding(),
             )
         },
         bottomBar = {

--- a/core/designsystem/src/main/kotlin/com/dhc/designsystem/topbar/DhcBasicTopBar.kt
+++ b/core/designsystem/src/main/kotlin/com/dhc/designsystem/topbar/DhcBasicTopBar.kt
@@ -30,12 +30,13 @@ import com.dhc.designsystem.topbar.model.TopBarPageState
 fun DhcBasicTopBar(
     title: String,
     isShowBackButton: Boolean,
+    modifier: Modifier = Modifier,
     topBarPageState: TopBarPageState? = null,
     onClickBackButton: () -> Unit,
 ) {
     val colors = LocalDhcColors.current
     Row(
-        modifier = Modifier
+        modifier = modifier
             .fillMaxWidth()
             .padding(start = 12.dp, end = 12.dp, top = 8.dp),
         verticalAlignment = Alignment.CenterVertically

--- a/core/designsystem/src/main/kotlin/com/dhc/designsystem/topbar/DhcTopBar.kt
+++ b/core/designsystem/src/main/kotlin/com/dhc/designsystem/topbar/DhcTopBar.kt
@@ -1,18 +1,21 @@
 package com.dhc.designsystem.topbar
 
 import androidx.compose.runtime.Composable
+import androidx.compose.ui.Modifier
 import com.dhc.designsystem.topbar.model.DhcTopBarState
 
 @Composable
 fun DhcTopBar(
     state: DhcTopBarState,
     navigateUp: () -> Unit,
+    modifier: Modifier = Modifier,
 ) {
     when (state) {
         is DhcTopBarState.Basic -> {
             DhcBasicTopBar(
                 title = state.title,
                 isShowBackButton = state.isShowBackButton,
+                modifier = modifier,
                 topBarPageState = state.topBarPageState,
                 onClickBackButton = navigateUp,
             )


### PR DESCRIPTION
## 개요
🔑**이슈 링크** : https://github.com/mash-up-kr/DHC-Android/issues/167


## 💻작업 내용  
- statueBarPadding 추가

## 🗣️To Reviwers  
- ㅠㅠ

## 👾시연 화면 (option)  

|Before|After|  
|---|---|
|<img width="249" alt="스크린샷 2025-06-15 오후 5 43 29" src="https://github.com/user-attachments/assets/cc494016-6c07-4cc5-b23c-5b884d519431" />|<img width="251" alt="스크린샷 2025-06-15 오후 5 42 41" src="https://github.com/user-attachments/assets/e9d9503e-eff4-4c4c-bc2b-c3f243168f26" />|



## Close 
close #167 
