### PR TITLE
[#160] 인트로 화면 - 운세카드 화면

### DIFF
--- a/app/src/main/java/com/dhc/dhcandroid/navigation/DhcNavHost.kt
+++ b/app/src/main/java/com/dhc/dhcandroid/navigation/DhcNavHost.kt
@@ -14,6 +14,7 @@ import androidx.navigation.compose.composable
 import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navigation
 import com.dhc.intro.description.IntroDescriptionRoute
+import com.dhc.intro.fortunecard.IntroFortuneCardRoute
 import com.dhc.intro.splash.SplashRoute
 import com.dhc.intro.start.IntroRoute
 
@@ -51,18 +52,9 @@ fun DhcNavHost(
                 )
             }
             composable(DhcRoute.INTRO_FORTUNE_CARD.route) {
-                Column(
-                    modifier = Modifier.fillMaxSize(),
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                    verticalArrangement = Arrangement.Center,
-                ) {
-                    Text("Intro Fortune Card")
-                    Button(
-                        onClick = { navController.navigateTo(DhcRoute.INTRO_FORTUNE_DETAIL) },
-                    ) {
-                        Text("Go to Next")
-                    }
-                }
+                IntroFortuneCardRoute(
+                    navigateToNextScreen = { navController.navigateTo(DhcRoute.INTRO_FORTUNE_DETAIL) },
+                )
             }
             composable(DhcRoute.INTRO_FORTUNE_DETAIL.route) {
                 Column(

--- a/app/src/main/java/com/dhc/dhcandroid/navigation/DhcNavHost.kt
+++ b/app/src/main/java/com/dhc/dhcandroid/navigation/DhcNavHost.kt
@@ -15,6 +15,7 @@ import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navigation
 import com.dhc.intro.description.IntroDescriptionRoute
 import com.dhc.intro.fortunecard.IntroFortuneCardRoute
+import com.dhc.intro.mission.IntroMissionRoute
 import com.dhc.intro.splash.SplashRoute
 import com.dhc.intro.start.IntroRoute
 
@@ -71,18 +72,9 @@ fun DhcNavHost(
                 }
             }
             composable(DhcRoute.INTRO_MISSION.route) {
-                Column(
-                    modifier = Modifier.fillMaxSize(),
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                    verticalArrangement = Arrangement.Center,
-                ) {
-                    Text("Intro Mission")
-                    Button(
-                        onClick = { navController.navigateTo(DhcRoute.INTRO_GENDER) },
-                    ) {
-                        Text("Go to Next")
-                    }
-                }
+                IntroMissionRoute(
+                    navigateToNextScreen = { navController.navigateTo(DhcRoute.INTRO_GENDER) },
+                )
             }
             composable(DhcRoute.INTRO_GENDER.route) {
                 Column(

--- a/core/common/src/main/java/com/dhc/common/CalendarUtil.kt
+++ b/core/common/src/main/java/com/dhc/common/CalendarUtil.kt
@@ -5,6 +5,8 @@ import java.time.Year
 
 object CalendarUtil {
 
+    fun getCurrentDate() = LocalDate.now()
+
     fun getCurrentYear(): Int = Year.now().value
 
     fun getActualMaximumDayOfMonth(year: Int, month: Int): Int =

--- a/core/designsystem/src/main/kotlin/com/dhc/designsystem/fortunecard/FlippableBox.kt
+++ b/core/designsystem/src/main/kotlin/com/dhc/designsystem/fortunecard/FlippableBox.kt
@@ -29,13 +29,13 @@ fun FlippableBox(
     flipThreshold: Float = 90f,
     initialRotationZ: Float = 0f,
 ) {
-    val initialIsFlipped by remember { mutableStateOf(isFlipped) }
+    val initialIsBack by remember { mutableStateOf(isFlipped) }
     var canRotate by remember { mutableStateOf(true) }
     var rotationAngleState by remember { mutableFloatStateOf(0f) }
     val animatedRotationAngleState by animateFloatAsState(targetValue = rotationAngleState, label = "")
     val isFront by remember(animatedRotationAngleState) {
         derivedStateOf {
-            if (initialIsFlipped) {
+            if (initialIsBack) {
                 false
             } else {
                 val angle = animatedRotationAngleState % 360
@@ -75,7 +75,7 @@ fun FlippableBox(
                 )
             }
             .graphicsLayer {
-                if (initialIsFlipped) {
+                if (initialIsBack) {
                     rotationY = 0f
                     rotationZ = 0f
                 } else {

--- a/core/designsystem/src/main/kotlin/com/dhc/designsystem/score/DhcScoreText.kt
+++ b/core/designsystem/src/main/kotlin/com/dhc/designsystem/score/DhcScoreText.kt
@@ -13,6 +13,7 @@ import androidx.compose.ui.unit.dp
 import com.dhc.designsystem.DhcTheme
 import com.dhc.designsystem.DhcTypoTokens
 import com.dhc.designsystem.GradientColor
+import com.dhc.designsystem.LocalDhcColors
 import com.dhc.designsystem.R
 import com.dhc.designsystem.SurfaceColor
 import com.dhc.designsystem.badge.DhcBadge
@@ -25,6 +26,7 @@ fun DhcScoreText(
     description: String,
     modifier: Modifier = Modifier,
 ) {
+    val colors = LocalDhcColors.current
     Column(
         verticalArrangement = Arrangement.spacedBy(12.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
@@ -41,7 +43,7 @@ fun DhcScoreText(
         Text(
             text = description,
             style = DhcTypoTokens.Body3,
-            color = SurfaceColor.neutral300,
+            color = colors.text.textBodyPrimary,
             textAlign = TextAlign.Center,
         )
     }

--- a/core/presentation/src/main/java/com/dhc/presentation/component/MissionTitle.kt
+++ b/core/presentation/src/main/java/com/dhc/presentation/component/MissionTitle.kt
@@ -1,0 +1,94 @@
+package com.dhc.presentation.component
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import androidx.compose.ui.unit.dp
+import com.dhc.designsystem.DhcTheme
+import com.dhc.designsystem.DhcTypoTokens
+import com.dhc.designsystem.LocalDhcColors
+import com.dhc.designsystem.SurfaceColor
+import com.dhc.designsystem.badge.DhcBadge
+import com.dhc.designsystem.badge.model.BadgeType
+
+@Composable
+fun MissionTitle(
+    title: String,
+    isInfoIconVisible: Boolean = false,
+    spendTypeText: String? = null,
+) {
+    val colors = LocalDhcColors.current
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = title,
+            color = colors.text.textBodyPrimary,
+            style = DhcTypoTokens.TitleH4_1,
+        )
+        if (isInfoIconVisible) {
+            Spacer(modifier = Modifier.width(8.dp))
+            Image(
+                painter = painterResource(com.dhc.designsystem.R.drawable.ico_info_circle),
+                contentDescription = "information",
+                colorFilter = ColorFilter.tint(SurfaceColor.neutral400)
+            )
+        }
+        if (spendTypeText != null) {
+            Spacer(modifier = Modifier.width(12.dp))
+            DhcBadge(
+                text = spendTypeText,
+                type = BadgeType.SpendType,
+            )
+        }
+    }
+}
+
+private class MissionTitlePreviewProvider :
+    PreviewParameterProvider<MissionTitlePreviewProvider.Parameter> {
+    override val values = sequenceOf(
+        Parameter(
+            title = "소비습관 미션",
+            isInfoIconVisible = true,
+            spendTypeText = "커피값 절약",
+        ),
+        Parameter(
+            title = "소비습관 미션",
+            isInfoIconVisible = false,
+            spendTypeText = null,
+        ),
+    )
+
+    data class Parameter(
+        val title: String,
+        val isInfoIconVisible: Boolean = false,
+        val spendTypeText: String? = null,
+    )
+}
+
+@Preview
+@Composable
+private fun MissionTitlePreview(
+    @PreviewParameter(MissionTitlePreviewProvider::class)
+    parameter: MissionTitlePreviewProvider.Parameter,
+) {
+    DhcTheme {
+        MissionTitle(
+            title = parameter.title,
+            isInfoIconVisible = parameter.isInfoIconVisible,
+            spendTypeText = parameter.spendTypeText,
+        )
+    }
+}

--- a/presentation/intro/src/main/java/com/dhc/intro/fortunecard/IntroFortuneCardContract.kt
+++ b/presentation/intro/src/main/java/com/dhc/intro/fortunecard/IntroFortuneCardContract.kt
@@ -1,0 +1,21 @@
+package com.dhc.intro.fortunecard
+
+import com.dhc.presentation.mvi.UiEvent
+import com.dhc.presentation.mvi.UiSideEffect
+import com.dhc.presentation.mvi.UiState
+
+class IntroFortuneCardContract {
+
+    data class State(
+        val isCardFlipped: Boolean = false,
+    ) : UiState
+
+    sealed interface Event : UiEvent {
+        data object FlippedFortuneCard : Event
+        data object ClickNextButton : Event
+    }
+
+    sealed interface SideEffect : UiSideEffect {
+        data object NavigateToNextScreen : SideEffect
+    }
+}

--- a/presentation/intro/src/main/java/com/dhc/intro/fortunecard/IntroFortuneCardRoute.kt
+++ b/presentation/intro/src/main/java/com/dhc/intro/fortunecard/IntroFortuneCardRoute.kt
@@ -1,0 +1,35 @@
+package com.dhc.intro.fortunecard
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Modifier
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.dhc.designsystem.SurfaceColor
+
+@Composable
+fun IntroFortuneCardRoute(
+    navigateToNextScreen: () -> Unit,
+    viewModel: IntroFortuneCardViewModel = hiltViewModel(),
+) {
+    val state by viewModel.state.collectAsState()
+
+    LaunchedEffect(Unit) {
+        viewModel.sideEffect.collect { sideEffect ->
+            when (sideEffect) {
+                IntroFortuneCardContract.SideEffect.NavigateToNextScreen -> navigateToNextScreen()
+            }
+        }
+    }
+
+    IntroFortuneCardScreen(
+        state = state,
+        modifier = Modifier
+            .fillMaxSize()
+            .background(SurfaceColor.neutral900), // Todo : Theme 적용 완료되면 background 제거하기
+        eventHandler = viewModel::sendEvent
+    )
+}

--- a/presentation/intro/src/main/java/com/dhc/intro/fortunecard/IntroFortuneCardScreen.kt
+++ b/presentation/intro/src/main/java/com/dhc/intro/fortunecard/IntroFortuneCardScreen.kt
@@ -37,6 +37,7 @@ import com.dhc.designsystem.fortunecard.DhcFortuneCard
 import com.dhc.designsystem.fortunecard.FlippableBox
 import com.dhc.designsystem.score.DhcScoreText
 import com.dhc.designsystem.title.DhcTitle
+import com.dhc.designsystem.title.DhcTitleState
 import com.dhc.intro.R
 import com.dhc.presentation.component.WordBalloon
 import com.dhc.presentation.mvi.EventHandler
@@ -58,9 +59,12 @@ fun IntroFortuneCardScreen(
         ) {
             Spacer(modifier = Modifier.height(24.dp))
             DhcTitle(
-                title = stringResource(R.string.intro_fortune_card_title),
+                titleState = DhcTitleState(
+                    title = stringResource(R.string.intro_fortune_card_title),
+                    titleStyle = DhcTypoTokens.TitleH2,
+                ),
                 textAlign = TextAlign.Center,
-                subTitle = null,
+                subTitleState = null,
                 modifier = Modifier
                     .fillMaxWidth()
                     .padding(top = 24.dp, start = 20.dp, end = 20.dp),

--- a/presentation/intro/src/main/java/com/dhc/intro/fortunecard/IntroFortuneCardScreen.kt
+++ b/presentation/intro/src/main/java/com/dhc/intro/fortunecard/IntroFortuneCardScreen.kt
@@ -70,7 +70,7 @@ fun IntroFortuneCardScreen(
             )
             Spacer(
                 modifier = Modifier
-                    .height(height = if (state.isCardFlipped.not()) 506.dp else 85.dp),
+                    .height(height = if (state.isCardFlipped.not()) 106.dp else 85.dp),
             )
             if (state.isCardFlipped.not()) {
                 NotFlippedDescription()

--- a/presentation/intro/src/main/java/com/dhc/intro/fortunecard/IntroFortuneCardScreen.kt
+++ b/presentation/intro/src/main/java/com/dhc/intro/fortunecard/IntroFortuneCardScreen.kt
@@ -48,7 +48,6 @@ fun IntroFortuneCardScreen(
     eventHandler: EventHandler<IntroFortuneCardContract.Event>,
     modifier: Modifier = Modifier,
 ) {
-    var cardFlipped: Boolean by remember { mutableStateOf(state.isCardFlipped) }
     Box(modifier = modifier) {
         Column(
             modifier = Modifier
@@ -86,9 +85,8 @@ fun IntroFortuneCardScreen(
             ) {
                 Spacer(modifier = Modifier.height(20.dp))
                 FlippableBox(
-                    isFlipped = cardFlipped,
+                    isFlipped = state.isCardFlipped,
                     onFlipEnd = {
-                        cardFlipped = true
                         eventHandler(IntroFortuneCardContract.Event.FlippedFortuneCard)
                     },
                     frontScreen = {

--- a/presentation/intro/src/main/java/com/dhc/intro/fortunecard/IntroFortuneCardScreen.kt
+++ b/presentation/intro/src/main/java/com/dhc/intro/fortunecard/IntroFortuneCardScreen.kt
@@ -12,8 +12,13 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
@@ -43,6 +48,7 @@ fun IntroFortuneCardScreen(
     eventHandler: EventHandler<IntroFortuneCardContract.Event>,
     modifier: Modifier = Modifier,
 ) {
+    var cardFlipped: Boolean by remember { mutableStateOf(state.isCardFlipped) }
     Box(modifier = modifier) {
         Column(
             modifier = Modifier
@@ -78,7 +84,11 @@ fun IntroFortuneCardScreen(
             ) {
                 Spacer(modifier = Modifier.height(20.dp))
                 FlippableBox(
-                    onFlipEnd = { eventHandler(IntroFortuneCardContract.Event.FlippedFortuneCard) },
+                    isFlipped = cardFlipped,
+                    onFlipEnd = {
+                        cardFlipped = true
+                        eventHandler(IntroFortuneCardContract.Event.FlippedFortuneCard)
+                    },
                     frontScreen = {
                         // Todo : 디자인 확정되면 수정하기
                         DhcFortuneCard(

--- a/presentation/intro/src/main/java/com/dhc/intro/fortunecard/IntroFortuneCardScreen.kt
+++ b/presentation/intro/src/main/java/com/dhc/intro/fortunecard/IntroFortuneCardScreen.kt
@@ -12,7 +12,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.layout.wrapContentHeight
-import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue

--- a/presentation/intro/src/main/java/com/dhc/intro/fortunecard/IntroFortuneCardScreen.kt
+++ b/presentation/intro/src/main/java/com/dhc/intro/fortunecard/IntroFortuneCardScreen.kt
@@ -51,7 +51,6 @@ fun IntroFortuneCardScreen(
     Box(modifier = modifier) {
         Column(
             modifier = Modifier
-                .animateContentSize()
                 .fillMaxWidth()
                 .wrapContentHeight(),
             horizontalAlignment = Alignment.CenterHorizontally,

--- a/presentation/intro/src/main/java/com/dhc/intro/fortunecard/IntroFortuneCardScreen.kt
+++ b/presentation/intro/src/main/java/com/dhc/intro/fortunecard/IntroFortuneCardScreen.kt
@@ -1,0 +1,160 @@
+package com.dhc.intro.fortunecard
+
+import androidx.compose.animation.animateContentSize
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.offset
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.width
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.dhc.common.CalendarUtil
+import com.dhc.designsystem.DhcTheme
+import com.dhc.designsystem.DhcTypoTokens
+import com.dhc.designsystem.GradientColor
+import com.dhc.designsystem.LocalDhcColors
+import com.dhc.designsystem.button.DhcButton
+import com.dhc.designsystem.button.model.DhcButtonSize
+import com.dhc.designsystem.button.model.DhcButtonStyle
+import com.dhc.designsystem.fortunecard.DhcFortuneCard
+import com.dhc.designsystem.fortunecard.FlippableBox
+import com.dhc.designsystem.score.DhcScoreText
+import com.dhc.designsystem.title.DhcTitle
+import com.dhc.intro.R
+import com.dhc.presentation.component.WordBalloon
+import com.dhc.presentation.mvi.EventHandler
+
+@Composable
+fun IntroFortuneCardScreen(
+    state: IntroFortuneCardContract.State,
+    eventHandler: EventHandler<IntroFortuneCardContract.Event>,
+    modifier: Modifier = Modifier,
+) {
+    Box(modifier = modifier) {
+        Column(
+            modifier = Modifier
+                .animateContentSize()
+                .fillMaxWidth()
+                .wrapContentHeight(),
+            horizontalAlignment = Alignment.CenterHorizontally,
+        ) {
+            Spacer(modifier = Modifier.height(24.dp))
+            DhcTitle(
+                title = stringResource(R.string.intro_fortune_card_title),
+                textAlign = TextAlign.Center,
+                subTitle = null,
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 24.dp, start = 20.dp, end = 20.dp),
+            )
+            Spacer(
+                modifier = Modifier
+                    .height(height = if (state.isCardFlipped.not()) 106.dp else 85.dp)
+                    .animateContentSize(),
+            )
+            if (state.isCardFlipped.not()) {
+                NotFlippedDescription()
+            } else {
+                FlippedDescription()
+            }
+            Box(
+                modifier = Modifier
+                    .size(width = 319.dp, height = 280.dp)
+                    .background(brush = GradientColor.backgroundGradient01)
+                    .offset(y = -(10.dp)),
+            ) {
+                Spacer(modifier = Modifier.height(20.dp))
+                FlippableBox(
+                    onFlipEnd = { eventHandler(IntroFortuneCardContract.Event.FlippedFortuneCard) },
+                    frontScreen = {
+                        // Todo : 디자인 확정되면 수정하기
+                        DhcFortuneCard(
+                            title = "?????",
+                            description = "",
+                            modifier = Modifier.width(width = 143.dp),
+                        )
+                    },
+                    backScreen = {
+                        // Todo : 디자인 확정되면 수정하기
+                        DhcFortuneCard(
+                            title = "오늘의 운세 카드",
+                            description = "'한템포 쉬어가기'",
+                            modifier = Modifier.width(width = 143.dp),
+                        )
+                    },
+                    modifier = Modifier.align(Alignment.Center),
+                    initialRotationZ = -4f,
+                )
+            }
+        }
+        if (state.isCardFlipped) {
+            DhcButton(
+                text = stringResource(R.string.start_with_finance_luck),
+                buttonSize = DhcButtonSize.XLARGE,
+                buttonStyle = DhcButtonStyle.Primary(isEnabled = true),
+                onClick = { eventHandler(IntroFortuneCardContract.Event.ClickNextButton) },
+                modifier = Modifier
+                    .padding(20.dp)
+                    .fillMaxWidth()
+                    .align(Alignment.BottomCenter),
+            )
+        }
+    }
+}
+
+@Composable
+private fun NotFlippedDescription() {
+    val colors = LocalDhcColors.current
+    Text(
+        text = stringResource(R.string.intro_fortune_card_description),
+        style = DhcTypoTokens.TitleH3,
+        color = colors.text.textBodyPrimary,
+        textAlign = TextAlign.Center,
+    )
+    Spacer(modifier = Modifier.height(48.dp))
+    WordBalloon(
+        gradientStartColor = Color(0xFFCFD4DE),
+        gradientEndColor = Color(0xFF9BA4D5),
+    ) {
+        Text(
+            text = stringResource(R.string.balloon_message_click),
+            style = DhcTypoTokens.TitleH7,
+            color = colors.text.textHighLightsPrimary,
+        )
+    }
+}
+
+@Composable
+private fun FlippedDescription() {
+    DhcScoreText(
+        badgeText = CalendarUtil.getCurrentDate().run {
+            stringResource(R.string.m_month_d_day_finance_luck, month.value, dayOfMonth)
+        },
+        score = 35,
+        description = "마음이 들뜨는 날이에요,\n한템포 쉬어가요.",
+    )
+}
+
+@Preview(showBackground = true)
+@Composable
+private fun IntroFortuneCardScreenPreview() {
+    DhcTheme {
+        IntroFortuneCardScreen(
+            state = IntroFortuneCardContract.State(),
+            eventHandler = {},
+        )
+    }
+}

--- a/presentation/intro/src/main/java/com/dhc/intro/fortunecard/IntroFortuneCardScreen.kt
+++ b/presentation/intro/src/main/java/com/dhc/intro/fortunecard/IntroFortuneCardScreen.kt
@@ -71,8 +71,7 @@ fun IntroFortuneCardScreen(
             )
             Spacer(
                 modifier = Modifier
-                    .height(height = if (state.isCardFlipped.not()) 106.dp else 85.dp)
-                    .animateContentSize(),
+                    .height(height = if (state.isCardFlipped.not()) 506.dp else 85.dp),
             )
             if (state.isCardFlipped.not()) {
                 NotFlippedDescription()

--- a/presentation/intro/src/main/java/com/dhc/intro/fortunecard/IntroFortuneCardViewModel.kt
+++ b/presentation/intro/src/main/java/com/dhc/intro/fortunecard/IntroFortuneCardViewModel.kt
@@ -1,0 +1,24 @@
+package com.dhc.intro.fortunecard
+
+import com.dhc.presentation.mvi.BaseViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import com.dhc.intro.fortunecard.IntroFortuneCardContract.State
+import com.dhc.intro.fortunecard.IntroFortuneCardContract.Event
+import com.dhc.intro.fortunecard.IntroFortuneCardContract.SideEffect
+
+@HiltViewModel
+class IntroFortuneCardViewModel @Inject constructor(
+) : BaseViewModel<State, Event, SideEffect>() {
+
+    override fun createInitialState(): State {
+        return State()
+    }
+
+    override suspend fun handleEvent(event: Event) {
+        when (event) {
+            Event.ClickNextButton -> postSideEffect(SideEffect.NavigateToNextScreen)
+            Event.FlippedFortuneCard -> reduce { copy(isCardFlipped = true) }
+        }
+    }
+}

--- a/presentation/intro/src/main/java/com/dhc/intro/mission/IntroMissionContract.kt
+++ b/presentation/intro/src/main/java/com/dhc/intro/mission/IntroMissionContract.kt
@@ -1,0 +1,18 @@
+package com.dhc.intro.mission
+
+import com.dhc.presentation.mvi.UiEvent
+import com.dhc.presentation.mvi.UiSideEffect
+import com.dhc.presentation.mvi.UiState
+
+class IntroMissionContract {
+
+    class State : UiState
+
+    sealed interface Event : UiEvent {
+        data object ClickNextButton : Event
+    }
+
+    sealed interface SideEffect : UiSideEffect {
+        data object NavigateToNextScreen : SideEffect
+    }
+}

--- a/presentation/intro/src/main/java/com/dhc/intro/mission/IntroMissionRoute.kt
+++ b/presentation/intro/src/main/java/com/dhc/intro/mission/IntroMissionRoute.kt
@@ -1,0 +1,30 @@
+package com.dhc.intro.mission
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Modifier
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.dhc.designsystem.SurfaceColor
+
+@Composable
+fun IntroMissionRoute(
+    navigateToNextScreen: () -> Unit,
+    viewModel: IntroMissionViewModel = hiltViewModel(),
+) {
+    LaunchedEffect(Unit) {
+        viewModel.sideEffect.collect { sideEffect ->
+            when (sideEffect) {
+                IntroMissionContract.SideEffect.NavigateToNextScreen -> navigateToNextScreen()
+            }
+        }
+    }
+
+    IntroMissionScreen(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(SurfaceColor.neutral900), // Todo : Theme 적용 완료되면 background 제거하기
+        eventHandler = viewModel::sendEvent
+    )
+}

--- a/presentation/intro/src/main/java/com/dhc/intro/mission/IntroMissionScreen.kt
+++ b/presentation/intro/src/main/java/com/dhc/intro/mission/IntroMissionScreen.kt
@@ -1,0 +1,165 @@
+package com.dhc.intro.mission
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.dhc.designsystem.DhcTheme
+import com.dhc.designsystem.DhcTypoTokens
+import com.dhc.designsystem.SurfaceColor
+import com.dhc.designsystem.button.DhcButton
+import com.dhc.designsystem.button.model.DhcButtonSize
+import com.dhc.designsystem.button.model.DhcButtonStyle
+import com.dhc.designsystem.mission.MoneyFortuneMissionCard
+import com.dhc.designsystem.mission.SpendingHabitMissionCard
+import com.dhc.designsystem.title.DhcTitle
+import com.dhc.designsystem.title.DhcTitleState
+import com.dhc.intro.R
+import com.dhc.presentation.component.MissionTitle
+import com.dhc.presentation.mvi.EventHandler
+
+@Composable
+fun IntroMissionScreen(
+    eventHandler: EventHandler<IntroMissionContract.Event>,
+    modifier: Modifier = Modifier,
+) {
+    Box(modifier = modifier) {
+        Column(modifier = Modifier.padding(horizontal = 20.dp)) {
+            Spacer(modifier = Modifier.height(24.dp))
+
+            DhcTitle(
+                titleState = DhcTitleState(
+                    title = stringResource(R.string.intro_mission_title),
+                    titleStyle = DhcTypoTokens.TitleH1,
+                ),
+                textAlign = TextAlign.Start,
+                subTitleState = DhcTitleState(
+                    title = stringResource(R.string.intro_mission_sub_title),
+                    titleStyle = DhcTypoTokens.Body3,
+                ),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 24.dp),
+            )
+
+            Spacer(modifier = Modifier.height(46.dp))
+
+            MissionTitle(
+                title = stringResource(R.string.spending_habit_mission),
+                isInfoIconVisible = true,
+                spendTypeText = "커피값 절약",
+            )
+            SpendingHabitMissionCard(
+                missionDday = "D-12",
+                missionTitle = "텀블러 들고 다니기",
+                isChecked = true,
+                isMissionEnabled = true,
+            )
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            MissionTitle(
+                title = stringResource(R.string.spending_habit_mission),
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            MoneyFortuneMissionCardList()
+        }
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(SurfaceColor.neutral900)
+                .align(Alignment.BottomCenter),
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(67.dp)
+                    .background(
+                        brush = Brush.verticalGradient(
+                            colors = listOf(Color.Transparent, SurfaceColor.neutral900),
+                        ),
+                    )
+            )
+            DhcButton(
+                text = stringResource(R.string.start_with_finance_luck),
+                buttonSize = DhcButtonSize.XLARGE,
+                buttonStyle = DhcButtonStyle.Secondary(isEnabled = true),
+                onClick = { eventHandler(IntroMissionContract.Event.ClickNextButton) },
+                modifier = Modifier
+                    .padding(20.dp)
+                    .fillMaxWidth()
+            )
+        }
+    }
+}
+
+@Composable
+private fun MoneyFortuneMissionCardList() {
+    val missionStateList = listOf(
+        MoneyFortuneMissionState(
+            missionMode = "Easy",
+            missionTitle = "가까운 거리 걸어다니기",
+            isChecked = true,
+            isMissionEnabled = true,
+        ),
+        MoneyFortuneMissionState(
+            missionMode = "Easy",
+            missionTitle = "가까운 거리 걸어다니기",
+            isChecked = false,
+            isMissionEnabled = true,
+        ),
+        MoneyFortuneMissionState(
+            missionMode = "Easy",
+            missionTitle = "가까운 거리 걸어다니기",
+            isChecked = false,
+            isMissionEnabled = true,
+        ),
+        MoneyFortuneMissionState(
+            missionMode = "Easy",
+            missionTitle = "가까운 거리 걸어다니기",
+            isChecked = false,
+            isMissionEnabled = true,
+        ),
+    )
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        missionStateList.forEach {
+            MoneyFortuneMissionCard(
+                missionMode = it.missionMode,
+                missionTitle = it.missionTitle,
+                isChecked = it.isChecked,
+                isMissionEnabled = it.isMissionEnabled,
+            )
+        }
+    }
+}
+
+private data class MoneyFortuneMissionState(
+    val missionMode: String,
+    val missionTitle: String,
+    val isChecked: Boolean,
+    val isMissionEnabled: Boolean,
+)
+
+@Preview(showBackground = true)
+@Composable
+private fun IntroMissionScreenPreview() {
+    DhcTheme {
+        IntroMissionScreen(eventHandler = {})
+    }
+}

--- a/presentation/intro/src/main/java/com/dhc/intro/mission/IntroMissionViewModel.kt
+++ b/presentation/intro/src/main/java/com/dhc/intro/mission/IntroMissionViewModel.kt
@@ -1,0 +1,23 @@
+package com.dhc.intro.mission
+
+import com.dhc.presentation.mvi.BaseViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import com.dhc.intro.mission.IntroMissionContract.State
+import com.dhc.intro.mission.IntroMissionContract.Event
+import com.dhc.intro.mission.IntroMissionContract.SideEffect
+
+@HiltViewModel
+class IntroMissionViewModel @Inject constructor(
+) : BaseViewModel<State, Event, SideEffect>() {
+
+    override fun createInitialState(): State {
+        return State()
+    }
+
+    override suspend fun handleEvent(event: Event) {
+        when (event) {
+            Event.ClickNextButton -> postSideEffect(SideEffect.NavigateToNextScreen)
+        }
+    }
+}

--- a/presentation/intro/src/main/res/values/strings.xml
+++ b/presentation/intro/src/main/res/values/strings.xml
@@ -8,4 +8,10 @@
     <string name="intro_description_text1">오늘의 금전운 받기</string>
     <string name="intro_description_text2">금전운에 따른 미션 수행</string>
     <string name="intro_description_text3">수행한 미션을 토대로 소비습관 분석</string>
+
+    <string name="intro_fortune_card_title">먼저 금전운을 하나\n받아볼까요?</string>
+    <string name="intro_fortune_card_description">오늘의 운세 카드를\n뒤집어보세요!</string>
+
+    <string name="m_month_d_day_finance_luck">%d월 %d일 금전운</string>
+    <string name="balloon_message_click">Click!</string>
 </resources>

--- a/presentation/intro/src/main/res/values/strings.xml
+++ b/presentation/intro/src/main/res/values/strings.xml
@@ -14,4 +14,8 @@
 
     <string name="m_month_d_day_finance_luck">%d월 %d일 금전운</string>
     <string name="balloon_message_click">Click!</string>
+
+    <string name="intro_mission_title">금전운에 기반해서\n부여된 미션이에요</string>
+    <string name="intro_mission_sub_title">미션을 수행하면서\n소비습관을 개선해보세요</string>
+    <string name="spending_habit_mission">소비습관 미션</string>
 </resources>


### PR DESCRIPTION
## 개요
🔑**이슈 링크** : https://github.com/mash-up-kr/DHC-Android/issues/160 


## 💻작업 내용  
- 인트로화면의 금전운 카드 뒤집기 화면을 구현했습니다.
- 카드에 대한 상세 디자인에 맞추어서 추가 개발될 예정입니당

## 🗣️To Reviwers  
- 찡끗

## 👾시연 화면 (option)  

|기능 구현|  
|---|
|<video src="https://github.com/user-attachments/assets/93e5a8eb-8aff-4c48-a8fc-2282a52d5f2f"/>|



## Close 
close #160 
