### PR TITLE
[#162] 인트로화면 - 미션확인

### DIFF
--- a/app/src/main/java/com/dhc/dhcandroid/navigation/DhcNavHost.kt
+++ b/app/src/main/java/com/dhc/dhcandroid/navigation/DhcNavHost.kt
@@ -15,6 +15,8 @@ import androidx.navigation.compose.rememberNavController
 import androidx.navigation.navigation
 import com.dhc.intro.description.IntroDescriptionRoute
 import com.dhc.intro.fortunecard.IntroFortuneCardRoute
+import com.dhc.intro.mission.IntroMissionRoute
+import com.dhc.intro.mission.IntroMissionScreen
 import com.dhc.intro.splash.SplashRoute
 import com.dhc.intro.start.IntroRoute
 
@@ -71,18 +73,9 @@ fun DhcNavHost(
                 }
             }
             composable(DhcRoute.INTRO_MISSION.route) {
-                Column(
-                    modifier = Modifier.fillMaxSize(),
-                    horizontalAlignment = Alignment.CenterHorizontally,
-                    verticalArrangement = Arrangement.Center,
-                ) {
-                    Text("Intro Mission")
-                    Button(
-                        onClick = { navController.navigateTo(DhcRoute.INTRO_GENDER) },
-                    ) {
-                        Text("Go to Next")
-                    }
-                }
+                IntroMissionRoute(
+                    navigateToNextScreen = { navController.navigateTo(DhcRoute.INTRO_GENDER) },
+                )
             }
             composable(DhcRoute.INTRO_GENDER.route) {
                 Column(

--- a/app/src/main/java/com/dhc/dhcandroid/navigation/DhcNavHost.kt
+++ b/app/src/main/java/com/dhc/dhcandroid/navigation/DhcNavHost.kt
@@ -16,7 +16,6 @@ import androidx.navigation.navigation
 import com.dhc.intro.description.IntroDescriptionRoute
 import com.dhc.intro.fortunecard.IntroFortuneCardRoute
 import com.dhc.intro.mission.IntroMissionRoute
-import com.dhc.intro.mission.IntroMissionScreen
 import com.dhc.intro.splash.SplashRoute
 import com.dhc.intro.start.IntroRoute
 

--- a/core/presentation/src/main/java/com/dhc/presentation/component/MissionTitle.kt
+++ b/core/presentation/src/main/java/com/dhc/presentation/component/MissionTitle.kt
@@ -1,0 +1,94 @@
+package com.dhc.presentation.component
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.tooling.preview.PreviewParameter
+import androidx.compose.ui.tooling.preview.PreviewParameterProvider
+import androidx.compose.ui.unit.dp
+import com.dhc.designsystem.DhcTheme
+import com.dhc.designsystem.DhcTypoTokens
+import com.dhc.designsystem.LocalDhcColors
+import com.dhc.designsystem.SurfaceColor
+import com.dhc.designsystem.badge.DhcBadge
+import com.dhc.designsystem.badge.model.BadgeType
+
+@Composable
+fun MissionTitle(
+    title: String,
+    isInfoIconVisible: Boolean = false,
+    spendTypeText: String? = null,
+) {
+    val colors = LocalDhcColors.current
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = title,
+            color = colors.text.textBodyPrimary,
+            style = DhcTypoTokens.TitleH4_1,
+        )
+        if (isInfoIconVisible) {
+            Spacer(modifier = Modifier.width(8.dp))
+            Image(
+                painter = painterResource(com.dhc.designsystem.R.drawable.ico_info_circle),
+                contentDescription = "information",
+                colorFilter = ColorFilter.tint(SurfaceColor.neutral400)
+            )
+        }
+        if (spendTypeText != null) {
+            Spacer(modifier = Modifier.width(12.dp))
+            DhcBadge(
+                text = spendTypeText,
+                type = BadgeType.SpendType,
+            )
+        }
+    }
+}
+
+private class MissionTitlePreviewProvider :
+    PreviewParameterProvider<MissionTitlePreviewProvider.Parameter> {
+    override val values = sequenceOf(
+        Parameter(
+            title = "소비습관 미션",
+            isInfoIconVisible = true,
+            spendTypeText = "커피값 절약",
+        ),
+        Parameter(
+            title = "소비습관 미션",
+            isInfoIconVisible = false,
+            spendTypeText = null,
+        ),
+    )
+
+    data class Parameter(
+        val title: String,
+        val isInfoIconVisible: Boolean = false,
+        val spendTypeText: String? = null,
+    )
+}
+
+@Preview
+@Composable
+private fun MissionTitlePreview(
+    @PreviewParameter(MissionTitlePreviewProvider::class)
+    parameter: MissionTitlePreviewProvider.Parameter,
+) {
+    DhcTheme {
+        MissionTitle(
+            title = parameter.title,
+            isInfoIconVisible = parameter.isInfoIconVisible,
+            spendTypeText = parameter.spendTypeText,
+        )
+    }
+}

--- a/presentation/intro/src/main/java/com/dhc/intro/mission/IntroMissionContract.kt
+++ b/presentation/intro/src/main/java/com/dhc/intro/mission/IntroMissionContract.kt
@@ -1,0 +1,18 @@
+package com.dhc.intro.mission
+
+import com.dhc.presentation.mvi.UiEvent
+import com.dhc.presentation.mvi.UiSideEffect
+import com.dhc.presentation.mvi.UiState
+
+class IntroMissionContract {
+
+    class State : UiState
+
+    sealed interface Event : UiEvent {
+        data object ClickNextButton : Event
+    }
+
+    sealed interface SideEffect : UiSideEffect {
+        data object NavigateToNextScreen : SideEffect
+    }
+}

--- a/presentation/intro/src/main/java/com/dhc/intro/mission/IntroMissionRoute.kt
+++ b/presentation/intro/src/main/java/com/dhc/intro/mission/IntroMissionRoute.kt
@@ -1,0 +1,30 @@
+package com.dhc.intro.mission
+
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.ui.Modifier
+import androidx.hilt.navigation.compose.hiltViewModel
+import com.dhc.designsystem.SurfaceColor
+
+@Composable
+fun IntroMissionRoute(
+    navigateToNextScreen: () -> Unit,
+    viewModel: IntroMissionViewModel = hiltViewModel(),
+) {
+    LaunchedEffect(Unit) {
+        viewModel.sideEffect.collect { sideEffect ->
+            when (sideEffect) {
+                IntroMissionContract.SideEffect.NavigateToNextScreen -> navigateToNextScreen()
+            }
+        }
+    }
+
+    IntroMissionScreen(
+        modifier = Modifier
+            .fillMaxSize()
+            .background(SurfaceColor.neutral900), // Todo : Theme 적용 완료되면 background 제거하기
+        eventHandler = viewModel::sendEvent
+    )
+}

--- a/presentation/intro/src/main/java/com/dhc/intro/mission/IntroMissionScreen.kt
+++ b/presentation/intro/src/main/java/com/dhc/intro/mission/IntroMissionScreen.kt
@@ -1,0 +1,209 @@
+package com.dhc.intro.mission
+
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.width
+import androidx.compose.material3.Text
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.style.TextAlign
+import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.dp
+import com.dhc.designsystem.DhcTheme
+import com.dhc.designsystem.DhcTypoTokens
+import com.dhc.designsystem.LocalDhcColors
+import com.dhc.designsystem.SurfaceColor
+import com.dhc.designsystem.badge.DhcBadge
+import com.dhc.designsystem.badge.model.BadgeType
+import com.dhc.designsystem.button.DhcButton
+import com.dhc.designsystem.button.model.DhcButtonSize
+import com.dhc.designsystem.button.model.DhcButtonStyle
+import com.dhc.designsystem.mission.MissionItemBackGround
+import com.dhc.designsystem.mission.MoneyFortuneMissionCard
+import com.dhc.designsystem.mission.SpendingHabitMissionCard
+import com.dhc.designsystem.title.DhcTitle
+import com.dhc.designsystem.title.DhcTitleState
+import com.dhc.intro.R
+import com.dhc.presentation.mvi.EventHandler
+
+@Composable
+fun IntroMissionScreen(
+    eventHandler: EventHandler<IntroMissionContract.Event>,
+    modifier: Modifier = Modifier,
+) {
+    Box(modifier = modifier) {
+        Column(modifier = Modifier.padding(horizontal = 20.dp)) {
+            Spacer(modifier = Modifier.height(24.dp))
+
+            DhcTitle(
+                titleState = DhcTitleState(
+                    title = stringResource(R.string.intro_mission_title),
+                    titleStyle = DhcTypoTokens.TitleH1,
+                ),
+                textAlign = TextAlign.Start,
+                subTitleState = DhcTitleState(
+                    title = stringResource(R.string.intro_mission_sub_title),
+                    titleStyle = DhcTypoTokens.Body3,
+                ),
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(top = 24.dp),
+            )
+
+            Spacer(modifier = Modifier.height(46.dp))
+
+            MissionTitle(
+                title = stringResource(R.string.spending_habit_mission),
+                isInfoIconVisible = true,
+                spendTypeText = "커피값 절약",
+            )
+            SpendingHabitMissionCard(
+                missionDday = "D-12",
+                missionTitle = "텀블러 들고 다니기",
+                isChecked = true,
+                isMissionEnabled = true,
+            )
+
+            Spacer(modifier = Modifier.height(24.dp))
+
+            MissionTitle(
+                title = stringResource(R.string.spending_habit_mission),
+            )
+            Spacer(modifier = Modifier.height(16.dp))
+            MoneyFortuneMissionCardList()
+        }
+        Column(
+            modifier = Modifier
+                .fillMaxWidth()
+                .background(SurfaceColor.neutral900)
+                .align(Alignment.BottomCenter),
+        ) {
+            Box(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .height(67.dp)
+                    .background(
+                        brush = Brush.verticalGradient(
+                            colors = listOf(Color.Transparent, SurfaceColor.neutral900),
+                        ),
+                    )
+            )
+            DhcButton(
+                text = stringResource(R.string.start_with_finance_luck),
+                buttonSize = DhcButtonSize.XLARGE,
+                buttonStyle = DhcButtonStyle.Secondary(isEnabled = true),
+                onClick = { eventHandler(IntroMissionContract.Event.ClickNextButton) },
+                modifier = Modifier
+                    .padding(20.dp)
+                    .fillMaxWidth()
+            )
+        }
+    }
+}
+
+@Composable
+private fun MissionTitle(
+    title: String,
+    isInfoIconVisible: Boolean = false,
+    spendTypeText: String? = null,
+
+    ) {
+    val colors = LocalDhcColors.current
+    Row(
+        modifier = Modifier.fillMaxWidth(),
+        verticalAlignment = Alignment.CenterVertically,
+    ) {
+        Text(
+            text = title,
+            color = colors.text.textBodyPrimary,
+            style = DhcTypoTokens.TitleH4_1,
+        )
+        if (isInfoIconVisible) {
+            Spacer(modifier = Modifier.width(8.dp))
+            Image(
+                painter = painterResource(com.dhc.designsystem.R.drawable.ico_info_circle),
+                contentDescription = "information",
+                colorFilter = ColorFilter.tint(SurfaceColor.neutral400)
+            )
+        }
+        if (spendTypeText != null) {
+            Spacer(modifier = Modifier.width(12.dp))
+            DhcBadge(
+                text = spendTypeText,
+                type = BadgeType.SpendType,
+            )
+        }
+    }
+}
+
+@Composable
+private fun MoneyFortuneMissionCardList() {
+    val missionStateList = listOf(
+        MoneyFortuneMissionState(
+            missionMode = "Easy",
+            missionTitle = "가까운 거리 걸어다니기",
+            isChecked = true,
+            isMissionEnabled = true,
+        ),
+        MoneyFortuneMissionState(
+            missionMode = "Easy",
+            missionTitle = "가까운 거리 걸어다니기",
+            isChecked = false,
+            isMissionEnabled = true,
+        ),
+        MoneyFortuneMissionState(
+            missionMode = "Easy",
+            missionTitle = "가까운 거리 걸어다니기",
+            isChecked = false,
+            isMissionEnabled = true,
+        ),
+        MoneyFortuneMissionState(
+            missionMode = "Easy",
+            missionTitle = "가까운 거리 걸어다니기",
+            isChecked = false,
+            isMissionEnabled = true,
+        ),
+    )
+    Column(
+        modifier = Modifier.fillMaxWidth(),
+        verticalArrangement = Arrangement.spacedBy(8.dp),
+    ) {
+        missionStateList.forEach {
+            MoneyFortuneMissionCard(
+                missionMode = it.missionMode,
+                missionTitle = it.missionTitle,
+                isChecked = it.isChecked,
+                isMissionEnabled = it.isMissionEnabled,
+            )
+        }
+    }
+}
+
+private data class MoneyFortuneMissionState(
+    val missionMode: String,
+    val missionTitle: String,
+    val isChecked: Boolean,
+    val isMissionEnabled: Boolean,
+)
+
+@Preview(showBackground = true)
+@Composable
+private fun IntroMissionScreenPreview() {
+    DhcTheme {
+        IntroMissionScreen(eventHandler = {})
+    }
+}

--- a/presentation/intro/src/main/java/com/dhc/intro/mission/IntroMissionScreen.kt
+++ b/presentation/intro/src/main/java/com/dhc/intro/mission/IntroMissionScreen.kt
@@ -1,43 +1,34 @@
 package com.dhc.intro.mission
 
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.width
-import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.ColorFilter
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.dhc.designsystem.DhcTheme
 import com.dhc.designsystem.DhcTypoTokens
-import com.dhc.designsystem.LocalDhcColors
 import com.dhc.designsystem.SurfaceColor
-import com.dhc.designsystem.badge.DhcBadge
-import com.dhc.designsystem.badge.model.BadgeType
 import com.dhc.designsystem.button.DhcButton
 import com.dhc.designsystem.button.model.DhcButtonSize
 import com.dhc.designsystem.button.model.DhcButtonStyle
-import com.dhc.designsystem.mission.MissionItemBackGround
 import com.dhc.designsystem.mission.MoneyFortuneMissionCard
 import com.dhc.designsystem.mission.SpendingHabitMissionCard
 import com.dhc.designsystem.title.DhcTitle
 import com.dhc.designsystem.title.DhcTitleState
 import com.dhc.intro.R
+import com.dhc.presentation.component.MissionTitle
 import com.dhc.presentation.mvi.EventHandler
 
 @Composable
@@ -110,41 +101,6 @@ fun IntroMissionScreen(
                 modifier = Modifier
                     .padding(20.dp)
                     .fillMaxWidth()
-            )
-        }
-    }
-}
-
-@Composable
-private fun MissionTitle(
-    title: String,
-    isInfoIconVisible: Boolean = false,
-    spendTypeText: String? = null,
-
-    ) {
-    val colors = LocalDhcColors.current
-    Row(
-        modifier = Modifier.fillMaxWidth(),
-        verticalAlignment = Alignment.CenterVertically,
-    ) {
-        Text(
-            text = title,
-            color = colors.text.textBodyPrimary,
-            style = DhcTypoTokens.TitleH4_1,
-        )
-        if (isInfoIconVisible) {
-            Spacer(modifier = Modifier.width(8.dp))
-            Image(
-                painter = painterResource(com.dhc.designsystem.R.drawable.ico_info_circle),
-                contentDescription = "information",
-                colorFilter = ColorFilter.tint(SurfaceColor.neutral400)
-            )
-        }
-        if (spendTypeText != null) {
-            Spacer(modifier = Modifier.width(12.dp))
-            DhcBadge(
-                text = spendTypeText,
-                type = BadgeType.SpendType,
             )
         }
     }

--- a/presentation/intro/src/main/java/com/dhc/intro/mission/IntroMissionViewModel.kt
+++ b/presentation/intro/src/main/java/com/dhc/intro/mission/IntroMissionViewModel.kt
@@ -1,0 +1,23 @@
+package com.dhc.intro.mission
+
+import com.dhc.presentation.mvi.BaseViewModel
+import dagger.hilt.android.lifecycle.HiltViewModel
+import javax.inject.Inject
+import com.dhc.intro.mission.IntroMissionContract.State
+import com.dhc.intro.mission.IntroMissionContract.Event
+import com.dhc.intro.mission.IntroMissionContract.SideEffect
+
+@HiltViewModel
+class IntroMissionViewModel @Inject constructor(
+) : BaseViewModel<State, Event, SideEffect>() {
+
+    override fun createInitialState(): State {
+        return State()
+    }
+
+    override suspend fun handleEvent(event: Event) {
+        when (event) {
+            Event.ClickNextButton -> postSideEffect(SideEffect.NavigateToNextScreen)
+        }
+    }
+}

--- a/presentation/intro/src/main/res/values/strings.xml
+++ b/presentation/intro/src/main/res/values/strings.xml
@@ -14,4 +14,8 @@
 
     <string name="m_month_d_day_finance_luck">%d월 %d일 금전운</string>
     <string name="balloon_message_click">Click!</string>
+
+    <string name="intro_mission_title">금전운에 기반해서\n부여된 미션이에요</string>
+    <string name="intro_mission_sub_title">미션을 수행하면서\n소비습관을 개선해보세요</string>
+    <string name="spending_habit_mission">소비습관 미션</string>
 </resources>


### PR DESCRIPTION
## 개요
🔑**이슈 링크** : https://github.com/mash-up-kr/DHC-Android/issues/162


## 💻작업 내용  
- 인트로화면의 미션확인 화면 구현하였습니다.
- 미션확인 화면에 있는 내용들은 모두 하드코딩 되어있습니다.

## 🗣️To Reviwers  
- 시연화면 보면 미션아이템이 figma 디자인과 쪼매 다른데, 이게 디자인시스템이 바뀐게 반영이 안되어서 그런지 디자인시스템 컬러 자체가 잘못 들어가 있더라구용.. 요건 별도 PR 로 수정하겠습니당  


## 👾시연 화면 (option)  

|기능 구현|  
|---|
|<video src="https://github.com/user-attachments/assets/747dc548-ad5d-4458-9e61-412061593515"/>|



## Close 
close #162 
