### PR TITLE
[#177] Fix : 디자인시스템에 맞게 색상 및 스타일 값 변경

### DIFF
--- a/core/designsystem/src/main/kotlin/com/dhc/designsystem/mission/MissionItemBackGround.kt
+++ b/core/designsystem/src/main/kotlin/com/dhc/designsystem/mission/MissionItemBackGround.kt
@@ -31,7 +31,7 @@ fun MissionItemBackGround(
     Row(
         modifier = modifier
             .fillMaxWidth()
-            .background(color = colors.background.backgroundMain, shape = RoundedCornerShape(12.dp))
+            .background(color = colors.background.backgroundGlassEffect, shape = RoundedCornerShape(12.dp))
             .padding(horizontal = 16.dp, vertical = 20.dp),
         horizontalArrangement = Arrangement.SpaceBetween,
         verticalAlignment = Alignment.CenterVertically

--- a/core/designsystem/src/main/kotlin/com/dhc/designsystem/mission/MoneyFortuneMissionCard.kt
+++ b/core/designsystem/src/main/kotlin/com/dhc/designsystem/mission/MoneyFortuneMissionCard.kt
@@ -61,7 +61,7 @@ fun MoneyFortuneMissionCard(
 
 @Composable
 @Preview
-private fun PreviewSpendingHabitMissionCard(
+private fun PreviewMoneyFortuneMissionCard(
     @PreviewParameter(MissionCardPreviewProvider::class)
     parameter: MissionCardPreviewProvider.Parameter,
 ) {

--- a/core/designsystem/src/main/kotlin/com/dhc/designsystem/mission/MoneyFortuneMissionCard.kt
+++ b/core/designsystem/src/main/kotlin/com/dhc/designsystem/mission/MoneyFortuneMissionCard.kt
@@ -51,10 +51,9 @@ fun MoneyFortuneMissionCard(
                 Spacer(modifier = Modifier.width(12.dp))
                 Text(
                     text = missionTitle,
-                    style = DhcTypoTokens.TitleH5,
+                    style = DhcTypoTokens.Body3,
                     color = missionColor,
-
-                    )
+                )
             }
         }
     )

--- a/core/designsystem/src/main/kotlin/com/dhc/designsystem/mission/SpendingHabitMissionCard.kt
+++ b/core/designsystem/src/main/kotlin/com/dhc/designsystem/mission/SpendingHabitMissionCard.kt
@@ -14,6 +14,7 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
@@ -62,7 +63,7 @@ fun SpendingHabitMissionCard(
                     Spacer(modifier = Modifier.width(12.dp))
                     Text(
                         text = missionTitle,
-                        style = DhcTypoTokens.TitleH5,
+                        style = DhcTypoTokens.Body3,
                         color = missionColor
                     )
                     Spacer(modifier = Modifier.width(16.dp))
@@ -72,7 +73,8 @@ fun SpendingHabitMissionCard(
         Image(
             modifier = Modifier.align(Alignment.TopStart).offset(x = 8.dp, y = (-12).dp),
             painter = painterResource(R.drawable.ico_pin),
-            contentDescription = "mission_card_pin"
+            contentDescription = "mission_card_pin",
+            colorFilter = ColorFilter.tint(color = SurfaceColor.neutral300),
         )
     }
 }


### PR DESCRIPTION
## 개요
🔑**이슈 링크** : https://github.com/mash-up-kr/DHC-Android/issues/177


## 💻작업 내용  
- Mission Item 이 색상과 스타일이 조금 다른 것 같아서 figma 에 맞게 수정해보았어요

## 🗣️To Reviwers  
- After 에 disabled 보면 D-3 글자가 안보이는데 놀랍게도 디자인시스템에 맞게 적용된 것입니다.. 🤔

## 👾시연 화면 (option)  

||Before|After|  
|---|---|---|
|Spending Habbit|<img width="332" alt="스크린샷 2025-06-18 오전 1 48 41" src="https://github.com/user-attachments/assets/094c7c8e-49e3-46f1-ba9e-419758832c16" />|<img width="331" alt="스크린샷 2025-06-18 오전 1 48 16" src="https://github.com/user-attachments/assets/b2440ce0-75b6-4e7a-bcb5-a1728073a2e8" />|
|Money Fortune|<img width="363" alt="스크린샷 2025-06-18 오전 1 50 33" src="https://github.com/user-attachments/assets/2d94f1ad-fe98-44d6-8a69-d001eb4037c7" />|<img width="361" alt="스크린샷 2025-06-18 오전 1 51 27" src="https://github.com/user-attachments/assets/606cd224-6aa0-4bc0-ba61-2cd8a298b3c6" />|


## Close 
close #177 
