### PR TITLE
[#204] 홈 TopBar 쪽 Gradient offset Topbar 크기 하드코딩하지 않도록 수정

### DIFF
--- a/presentation/home/src/main/java/com/dhc/home/main/HomeScreen.kt
+++ b/presentation/home/src/main/java/com/dhc/home/main/HomeScreen.kt
@@ -6,12 +6,13 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
@@ -19,8 +20,10 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
 import com.dhc.designsystem.DhcTheme
 import com.dhc.designsystem.DhcTypoTokens
@@ -41,11 +44,13 @@ fun HomeScreen(
     Box(
         modifier = modifier.fillMaxSize()
     ) {
+        val density = LocalDensity.current
+        val topBarSize = WindowInsets.statusBars.getTop(density)
         Box(
             modifier = Modifier
                 .fillMaxWidth()
                 .height(466.dp)
-                .offset(y = -(54.dp))
+                .offset(y = -(topBarSize.div(density.density).dp))
                 .background(brush = GradientColor.backgroundGradient02Alpha(0.6f))
         )
         Column(


### PR DESCRIPTION
## 개요
🔑**이슈 링크** : https://github.com/mash-up-kr/DHC-Android/issues/204


## 💻작업 내용  
- 54.dp 가 대충 디바이스 탑바 크기에 맞춘건데, 탑바사이즈는 기기별로 달라서 모든 기기에 대응될 수 있도록 기기의 탑바를 가져와서 offset 을 적용하는 것으로 수정했습니다

## 🗣️To Reviwers  
- 찡끗


## Close 
close #204
