### PR TITLE
[#244] 카테고리 정보 가져오기 Api 및 data model 추가

### DIFF
--- a/data/src/main/kotlin/com/dhc/dhcandroid/model/MissionCategoriesResponse.kt
+++ b/data/src/main/kotlin/com/dhc/dhcandroid/model/MissionCategoriesResponse.kt
@@ -1,0 +1,15 @@
+package com.dhc.dhcandroid.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class MissionCategoriesResponse(
+    val categories: List<String> = emptyList(),
+)
+
+@Serializable
+data class MissionCategoryResponse(
+    val name: MissionCategory? = null,
+    val displayName: String = "",
+    val imageUrl: String = "",
+)

--- a/data/src/main/kotlin/com/dhc/dhcandroid/service/DhcService.kt
+++ b/data/src/main/kotlin/com/dhc/dhcandroid/service/DhcService.kt
@@ -41,6 +41,10 @@ interface DhcService {
         @Path("userId") userId: String,
     ): Response<LogoutResponse>
 
+    @GET("/api/mission-categories")
+    suspend fun getMissionCategories(
+    ): Response<AnalysisViewResponse>
+
     @GET("/view/users/{userId}/home")
     suspend fun getHomeView(
         @Path("userId") userId: String,


### PR DESCRIPTION
## 개요
🔑**이슈 링크** : https://github.com/mash-up-kr/DHC-Android/issues/244

<img width="1369" alt="image" src="https://github.com/user-attachments/assets/95d13af9-e3e1-4778-8a17-16230d901138" />



## 💻작업 내용  
- mission category 가져오는 API 랑 데이터모델 추가했어용


## 🗣️To Reviwers  
- 찡끗

## Close 
close #244 
