### PR TITLE
[#246] 인트로 카테고리 정보 서버에서 받아오도록 수정

### DIFF
--- a/app/src/main/java/com/dhc/dhcandroid/navigation/DhcNavHost.kt
+++ b/app/src/main/java/com/dhc/dhcandroid/navigation/DhcNavHost.kt
@@ -102,7 +102,7 @@ fun DhcNavHost(
             }
             composable(DhcRoute.INTRO_CATEGORY.route) {
                 IntroCategoryRoute(
-                    navigateToNextScreen = { navController.navigateToHome() },
+                    navigateToNextScreen = { navController.navigateToHomeFromIntro() },
                 )
             }
         }

--- a/app/src/main/java/com/dhc/dhcandroid/navigation/DhcNavHost.kt
+++ b/app/src/main/java/com/dhc/dhcandroid/navigation/DhcNavHost.kt
@@ -42,7 +42,7 @@ fun DhcNavHost(
             SplashRoute(
                 navigateToNextScreen = {
 //                    navController.navigateToHomeFromIntro()
-                     navController.navigateToIntroFromSplash()
+                    navController.navigateToIntroFromSplash()
                 },
             )
         }

--- a/app/src/main/java/com/dhc/dhcandroid/navigation/DhcNavHost.kt
+++ b/app/src/main/java/com/dhc/dhcandroid/navigation/DhcNavHost.kt
@@ -41,8 +41,8 @@ fun DhcNavHost(
         composable(DhcRoute.SPLASH.route) {
             SplashRoute(
                 navigateToNextScreen = {
-                    navController.navigateToHomeFromIntro()
-                    // navController.navigateToIntroFromSplash()
+//                    navController.navigateToHomeFromIntro()
+                     navController.navigateToIntroFromSplash()
                 },
             )
         }

--- a/core/common/src/main/kotlin/com/dhc/common/DhcResult.kt
+++ b/core/common/src/main/kotlin/com/dhc/common/DhcResult.kt
@@ -26,3 +26,5 @@ inline fun <T> DhcResult<T>.onException(action: (Throwable) -> Unit): DhcResult<
     }
     return this
 }
+
+fun <T> DhcResult<T>.getSuccessOrNull() = if (this is DhcResult.Success) this.data else null

--- a/data/src/main/kotlin/com/dhc/dhcandroid/datasource/DhcRemoteDataSource.kt
+++ b/data/src/main/kotlin/com/dhc/dhcandroid/datasource/DhcRemoteDataSource.kt
@@ -6,6 +6,7 @@ import com.dhc.dhcandroid.model.EndTodayMissionResponse
 import com.dhc.dhcandroid.model.HomeViewResponse
 import com.dhc.dhcandroid.model.LogoutResponse
 import com.dhc.dhcandroid.model.Mission
+import com.dhc.dhcandroid.model.MissionCategoriesResponse
 import com.dhc.dhcandroid.model.MyPageResponse
 import com.dhc.dhcandroid.model.RegisterUserResponse
 import com.dhc.dhcandroid.model.ToggleMissionRequest
@@ -42,4 +43,7 @@ interface DhcRemoteDataSource {
     suspend fun getAnalysisView(
         userId: String,
     ): Response<AnalysisViewResponse>
+
+    suspend fun getMissionCategories(
+    ): Response<MissionCategoriesResponse>
 }

--- a/data/src/main/kotlin/com/dhc/dhcandroid/datasource/DhcRemoteDataSourceImpl.kt
+++ b/data/src/main/kotlin/com/dhc/dhcandroid/datasource/DhcRemoteDataSourceImpl.kt
@@ -6,6 +6,7 @@ import com.dhc.dhcandroid.model.EndTodayMissionResponse
 import com.dhc.dhcandroid.model.HomeViewResponse
 import com.dhc.dhcandroid.model.LogoutResponse
 import com.dhc.dhcandroid.model.Mission
+import com.dhc.dhcandroid.model.MissionCategoriesResponse
 import com.dhc.dhcandroid.model.MyPageResponse
 import com.dhc.dhcandroid.model.RegisterUserResponse
 import com.dhc.dhcandroid.model.ToggleMissionRequest
@@ -49,4 +50,7 @@ class DhcRemoteDataSourceImpl @Inject constructor(
         return dhcService.getAnalysisView(userId)
     }
 
+    override suspend fun getMissionCategories(): Response<MissionCategoriesResponse> {
+        return dhcService.getMissionCategories()
+    }
 }

--- a/data/src/main/kotlin/com/dhc/dhcandroid/model/MissionCategoriesResponse.kt
+++ b/data/src/main/kotlin/com/dhc/dhcandroid/model/MissionCategoriesResponse.kt
@@ -4,7 +4,7 @@ import kotlinx.serialization.Serializable
 
 @Serializable
 data class MissionCategoriesResponse(
-    val categories: List<String> = emptyList(),
+    val categories: List<MissionCategoryResponse> = emptyList(),
 )
 
 @Serializable

--- a/data/src/main/kotlin/com/dhc/dhcandroid/repository/DhcRepository.kt
+++ b/data/src/main/kotlin/com/dhc/dhcandroid/repository/DhcRepository.kt
@@ -7,6 +7,7 @@ import com.dhc.dhcandroid.model.EndTodayMissionResponse
 import com.dhc.dhcandroid.model.HomeViewResponse
 import com.dhc.dhcandroid.model.LogoutResponse
 import com.dhc.dhcandroid.model.Mission
+import com.dhc.dhcandroid.model.MissionCategoriesResponse
 import com.dhc.dhcandroid.model.MyPageResponse
 import com.dhc.dhcandroid.model.RegisterUserResponse
 import com.dhc.dhcandroid.model.ToggleMissionRequest
@@ -42,4 +43,7 @@ interface DhcRepository {
     suspend fun getAnalysisView(
         userId: String,
     ): DhcResult<AnalysisViewResponse>
+
+    suspend fun getMissionCategories(
+    ): DhcResult<MissionCategoriesResponse>
 }

--- a/data/src/main/kotlin/com/dhc/dhcandroid/repository/DhcRepositoryImpl.kt
+++ b/data/src/main/kotlin/com/dhc/dhcandroid/repository/DhcRepositoryImpl.kt
@@ -8,6 +8,7 @@ import com.dhc.dhcandroid.model.EndTodayMissionResponse
 import com.dhc.dhcandroid.model.HomeViewResponse
 import com.dhc.dhcandroid.model.LogoutResponse
 import com.dhc.dhcandroid.model.Mission
+import com.dhc.dhcandroid.model.MissionCategoriesResponse
 import com.dhc.dhcandroid.model.MyPageResponse
 import com.dhc.dhcandroid.model.RegisterUserResponse
 import com.dhc.dhcandroid.model.ToggleMissionRequest
@@ -48,4 +49,7 @@ class DhcRepositoryImpl @Inject constructor(
 
     override suspend fun getAnalysisView(userId: String): DhcResult<AnalysisViewResponse> =
         runDhcCatching { dhcRemoteDataSource.getAnalysisView(userId) }
+
+    override suspend fun getMissionCategories(): DhcResult<MissionCategoriesResponse> =
+        runDhcCatching { dhcRemoteDataSource.getMissionCategories() }
 }

--- a/data/src/main/kotlin/com/dhc/dhcandroid/service/DhcService.kt
+++ b/data/src/main/kotlin/com/dhc/dhcandroid/service/DhcService.kt
@@ -6,6 +6,7 @@ import com.dhc.dhcandroid.model.EndTodayMissionResponse
 import com.dhc.dhcandroid.model.HomeViewResponse
 import com.dhc.dhcandroid.model.LogoutResponse
 import com.dhc.dhcandroid.model.Mission
+import com.dhc.dhcandroid.model.MissionCategoriesResponse
 import com.dhc.dhcandroid.model.MyPageResponse
 import com.dhc.dhcandroid.model.RegisterUserResponse
 import com.dhc.dhcandroid.model.ToggleMissionRequest
@@ -43,7 +44,7 @@ interface DhcService {
 
     @GET("/api/mission-categories")
     suspend fun getMissionCategories(
-    ): Response<AnalysisViewResponse>
+    ): Response<MissionCategoriesResponse>
 
     @GET("/view/users/{userId}/home")
     suspend fun getHomeView(

--- a/presentation/intro/src/main/java/com/dhc/intro/category/IntroCategoryScreen.kt
+++ b/presentation/intro/src/main/java/com/dhc/intro/category/IntroCategoryScreen.kt
@@ -14,8 +14,6 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.lazy.grid.GridCells
 import androidx.compose.foundation.lazy.grid.LazyVerticalGrid
 import androidx.compose.foundation.lazy.grid.itemsIndexed
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
@@ -72,15 +70,14 @@ fun IntroCategoryScreen(
             ) {
                 itemsIndexed(
                     items = state.categoryItems,
-                    key = { _, item -> item.id },
+                    key = { _, item -> item.toString() },
                 ) { categoryIndex, item ->
                     DhcCategoryItem(
-                        name = item.name,
-                        isChecked = state.selectedIndexSet.contains(categoryIndex),
+                        name = item.displayName,
                         imageUrl = item.imageUrl,
+                        isChecked = state.selectedIndexSet.contains(categoryIndex),
                         modifier = Modifier
                             .fillMaxWidth()
-                            .aspectRatio(1.6f)
                             .clickable {
                                 eventHandler(
                                     IntroCategoryContract.Event.ClickCategoryItem(categoryIndex)
@@ -96,7 +93,7 @@ fun IntroCategoryScreen(
             buttonStyle = DhcButtonStyle.Secondary(isEnabled = state.nextButtonEnabled),
             onClick = {
                 if (state.nextButtonEnabled) {
-                    eventHandler(IntroCategoryContract.Event.ClickNextButton(state))
+                    eventHandler(IntroCategoryContract.Event.ClickNextButton(currentState = state))
                 }
             },
             modifier = Modifier

--- a/presentation/intro/src/main/java/com/dhc/intro/category/IntroCategoryViewModel.kt
+++ b/presentation/intro/src/main/java/com/dhc/intro/category/IntroCategoryViewModel.kt
@@ -1,5 +1,8 @@
 package com.dhc.intro.category
 
+import androidx.lifecycle.viewModelScope
+import com.dhc.common.getSuccessOrNull
+import com.dhc.dhcandroid.repository.DhcRepository
 import com.dhc.dhcandroid.repository.UserRepository
 import com.dhc.presentation.mvi.BaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -8,33 +11,39 @@ import com.dhc.intro.category.IntroCategoryContract.State
 import com.dhc.intro.category.IntroCategoryContract.Event
 import com.dhc.intro.category.IntroCategoryContract.SideEffect
 import com.dhc.intro.category.model.CategoryItem
+import kotlinx.coroutines.launch
 
 @HiltViewModel
 class IntroCategoryViewModel @Inject constructor(
-    private val repository: UserRepository,
+    private val userRepository: UserRepository,
+    private val dhcRepository: DhcRepository,
 ) : BaseViewModel<State, Event, SideEffect>() {
+
+    init {
+        viewModelScope.launch {
+            val categoryItems = dhcRepository.getMissionCategories().getSuccessOrNull()?.categories?.map {
+                CategoryItem(
+                    name = it.name,
+                    displayName = it.displayName,
+                    imageUrl = it.imageUrl
+                )
+            } ?: emptyList()
+
+            reduce { copy(categoryItems = categoryItems) }
+        }
+    }
 
     override fun createInitialState(): State {
         return State(
-            categoryItems = listOf( // Todo : 서버에서 받아오기
-                CategoryItem(0, "식음료", "https://cdn.dailyvet.co.kr/wp-content/uploads/2024/05/15231710/20240515ceva_experts5.jpg"),
-                CategoryItem(1, "이동/교통", "https://cdn.dailyvet.co.kr/wp-content/uploads/2024/05/15231710/20240515ceva_experts5.jpg"),
-                CategoryItem(2, "디지털/구독", "https://cdn.dailyvet.co.kr/wp-content/uploads/2024/05/15231710/20240515ceva_experts5.jpg"),
-                CategoryItem(3, "쇼핑", "https://cdn.dailyvet.co.kr/wp-content/uploads/2024/05/15231710/20240515ceva_experts5.jpg"),
-                CategoryItem(4, "취미/문화", "https://blog.malcang.com/wp-content/uploads/2024/03/1-1.png"),
-                CategoryItem(5, "사교/모임", "https://upload.wikimedia.org/wikipedia/commons/thumb/e/e6/Noto_Emoji_KitKat_263a.svg/1200px-Noto_Emoji_KitKat_263a.svg.png"),
-            )
+            categoryItems = emptyList()
         )
     }
 
     override suspend fun handleEvent(event: Event) {
         when (event) {
             is Event.ClickNextButton -> {
-                val selectedCategory = event.currentState.categoryItems.filterIndexed { index, _ ->
-                    event.currentState.selectedIndexSet.contains(index)
-                }
-                repository.updateCategory(selectedCategory.map { it.toServerType() })
-                repository.updateUserProfile()
+                userRepository.updateCategory(event.currentState.categoryItems.map { it.toServerType() })
+                userRepository.updateUserProfile()
                 postSideEffect(SideEffect.NavigateToNextScreen)
             }
             is Event.ClickCategoryItem -> reduce {

--- a/presentation/intro/src/main/java/com/dhc/intro/category/model/CategoryItem.kt
+++ b/presentation/intro/src/main/java/com/dhc/intro/category/model/CategoryItem.kt
@@ -3,9 +3,9 @@ package com.dhc.intro.category.model
 import com.dhc.dhcandroid.model.MissionCategory
 
 data class CategoryItem(
-    val id: Int,
-    val name: String,
-    val imageUrl: String,
+    val name: MissionCategory? = null,
+    val displayName: String = "",
+    val imageUrl: String = "",
 ) {
     fun toServerType(): MissionCategory = MissionCategory.TRANSPORTATION // Todo : 임시 코드
 }

--- a/presentation/mypage/src/main/kotlin/com/dhc/mypage/MyPageViewModel.kt
+++ b/presentation/mypage/src/main/kotlin/com/dhc/mypage/MyPageViewModel.kt
@@ -1,11 +1,10 @@
 package com.dhc.mypage
 
-import androidx.lifecycle.SavedStateHandle
 import androidx.lifecycle.viewModelScope
 import com.dhc.common.onFailure
 import com.dhc.common.onSuccess
 import com.dhc.dhcandroid.repository.DhcRepository
-import com.dhc.dhcandroid.repository.UserDataStoreRepository
+import com.dhc.dhcandroid.repository.AuthDataStoreRepository
 import com.dhc.mypage.MyPageContract.Event
 import com.dhc.mypage.MyPageContract.SideEffect
 import com.dhc.mypage.MyPageContract.State
@@ -18,7 +17,7 @@ import javax.inject.Inject
 
 @HiltViewModel
 class MyPageViewModel @Inject constructor(
-    private val userRepository: UserDataStoreRepository,
+    private val userRepository: AuthDataStoreRepository,
     private val dhcRepository: DhcRepository,
 ) : BaseViewModel<State, Event, SideEffect>() {
     override fun createInitialState(): State {


### PR DESCRIPTION
## 개요
🔑**이슈 링크** : https://github.com/mash-up-kr/DHC-Android/issues/246


## 💻작업 내용  
- 서버에서 가져와서 보여주도록 구현해보았어용


## 🗣️To Reviwers  
- 히히

## 👾시연 화면 (option)  

|기능 구현|  
|---|
|<img width="262" alt="스크린샷 2025-06-28 오후 10 54 22" src="https://github.com/user-attachments/assets/cd9c57f7-4b9c-422f-9cf9-ed7d69aade01" />|



## Close 
close #246 
