### PR TITLE
[#259] Feature : 마이페이지 카테고리 서버 데이터 연동

### DIFF
--- a/data/src/main/kotlin/com/dhc/dhcandroid/model/MyPageResponse.kt
+++ b/data/src/main/kotlin/com/dhc/dhcandroid/model/MyPageResponse.kt
@@ -7,7 +7,7 @@ data class MyPageResponse(
     val animalCard: AnimalCard = AnimalCard(),
     val birthDate: BirthDate? = null,
     val birthTime: String? = null,
-    val preferredMissionCategoryList: List<MissionCategory> = emptyList(),
+    val preferredMissionCategoryList: List<MissionCategoryResponse> = emptyList(),
     val alarm: Boolean = false,
 )
 

--- a/presentation/mypage/src/main/kotlin/com/dhc/mypage/MyPageContract.kt
+++ b/presentation/mypage/src/main/kotlin/com/dhc/mypage/MyPageContract.kt
@@ -1,6 +1,6 @@
 package com.dhc.mypage
 
-import com.dhc.dhcandroid.model.MissionCategory
+import com.dhc.mypage.model.MissionCategoryUiModel
 import com.dhc.mypage.model.MyInfoUiModel
 import com.dhc.presentation.mvi.UiEvent
 import com.dhc.presentation.mvi.UiSideEffect
@@ -10,7 +10,7 @@ class MyPageContract {
 
     data class State(
         val myInfo: MyInfoUiModel = MyInfoUiModel(),
-        val missionCategories: List<MissionCategory> = emptyList(),
+        val missionCategories: List<MissionCategoryUiModel> = emptyList(),
         val isShowAppResetDialog: Boolean = false,
     ) : UiState
 

--- a/presentation/mypage/src/main/kotlin/com/dhc/mypage/MyPageViewModel.kt
+++ b/presentation/mypage/src/main/kotlin/com/dhc/mypage/MyPageViewModel.kt
@@ -8,6 +8,7 @@ import com.dhc.dhcandroid.repository.DhcRepository
 import com.dhc.mypage.MyPageContract.Event
 import com.dhc.mypage.MyPageContract.SideEffect
 import com.dhc.mypage.MyPageContract.State
+import com.dhc.mypage.model.MissionCategoryUiModel
 import com.dhc.mypage.model.MyInfoUiModel
 import com.dhc.presentation.mvi.BaseViewModel
 import dagger.hilt.android.lifecycle.HiltViewModel
@@ -32,6 +33,7 @@ class MyPageViewModel @Inject constructor(
                 reduce { copy(isShowAppResetDialog = false) }
                 postSideEffect(SideEffect.NavigateToIntro)
             }
+
             is Event.ClickDialogDismissButton -> reduce { copy(isShowAppResetDialog = false) }
         }
     }
@@ -44,7 +46,11 @@ class MyPageViewModel @Inject constructor(
                 reduce {
                     copy(
                         myInfo = MyInfoUiModel.from(myPageResponse = response),
-                        missionCategories = response.preferredMissionCategoryList,
+                        missionCategories = response.preferredMissionCategoryList.map {
+                            MissionCategoryUiModel.from(
+                                it
+                            )
+                        },
                     )
                 }
             }

--- a/presentation/mypage/src/main/kotlin/com/dhc/mypage/model/MissionCategoryUiModel.kt
+++ b/presentation/mypage/src/main/kotlin/com/dhc/mypage/model/MissionCategoryUiModel.kt
@@ -1,0 +1,19 @@
+package com.dhc.mypage.model
+
+import com.dhc.dhcandroid.model.MissionCategory
+import com.dhc.dhcandroid.model.MissionCategoryResponse
+
+data class MissionCategoryUiModel(
+    val name: MissionCategory? = null,
+    val displayName: String = "",
+    val imageUrl: String = "",
+) {
+    companion object {
+        fun from(missionCategoryResponse: MissionCategoryResponse) =
+            MissionCategoryUiModel(
+                name = missionCategoryResponse.name,
+                displayName = missionCategoryResponse.displayName,
+                imageUrl = missionCategoryResponse.imageUrl
+            )
+    }
+}

--- a/presentation/mypage/src/main/kotlin/com/dhc/mypage/ui/MyPageScreen.kt
+++ b/presentation/mypage/src/main/kotlin/com/dhc/mypage/ui/MyPageScreen.kt
@@ -31,6 +31,7 @@ import com.dhc.designsystem.category.DhcCategoryItem
 import com.dhc.mypage.MyPageContract.Event
 import com.dhc.mypage.MyPageContract.State
 import com.dhc.mypage.R
+import com.dhc.mypage.model.MissionCategoryUiModel
 import com.dhc.mypage.model.MyInfoUiModel
 import com.dhc.mypage.ui.settinglist.SettingItem
 import com.dhc.mypage.ui.settinglist.SettingList
@@ -67,7 +68,10 @@ fun MyPageScreen(
             modifier = Modifier.fillMaxWidth(),
         )
 
-        SelectedCategory(modifier = Modifier.fillMaxWidth())
+        SelectedCategory(
+            categoryList = state.missionCategories,
+            modifier = Modifier.fillMaxWidth()
+        )
 
         HorizontalDivider(
             thickness = 7.dp,
@@ -109,7 +113,10 @@ private fun MyInfo(
 }
 
 @Composable
-private fun SelectedCategory(modifier: Modifier = Modifier) {
+private fun SelectedCategory(
+    categoryList: List<MissionCategoryUiModel>,
+    modifier: Modifier = Modifier
+) {
     Column(
         modifier = modifier.padding(vertical = 24.dp),
         verticalArrangement = Arrangement.spacedBy(12.dp),
@@ -125,12 +132,13 @@ private fun SelectedCategory(modifier: Modifier = Modifier) {
             contentPadding = PaddingValues(horizontal = 20.dp),
             horizontalArrangement = Arrangement.spacedBy(8.dp)
         ) {
-            items(5) {
+            items(categoryList.size) { index ->
+                val category = categoryList[index]
                 DhcCategoryItem(
                     modifier = Modifier.width(120.dp),
-                    name = "식음료",
+                    name = category.displayName,
                     isChecked = false,
-                    imageUrl = "sampleImageUrl",
+                    imageUrl = category.imageUrl,
                 )
             }
         }

--- a/presentation/mypage/src/main/kotlin/com/dhc/mypage/ui/MyPageScreen.kt
+++ b/presentation/mypage/src/main/kotlin/com/dhc/mypage/ui/MyPageScreen.kt
@@ -12,6 +12,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
 import androidx.compose.foundation.layout.width
 import androidx.compose.foundation.lazy.LazyRow
+import androidx.compose.foundation.lazy.items
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.HorizontalDivider
@@ -132,8 +133,7 @@ private fun SelectedCategory(
             contentPadding = PaddingValues(horizontal = 20.dp),
             horizontalArrangement = Arrangement.spacedBy(8.dp)
         ) {
-            items(categoryList.size) { index ->
-                val category = categoryList[index]
+            items(categoryList) { category ->
                 DhcCategoryItem(
                     modifier = Modifier.width(120.dp),
                     name = category.displayName,


### PR DESCRIPTION
## 개요
🔑**이슈 링크** : https://github.com/mash-up-kr/DHC-Android/issues/259


## 💻작업 내용  
 >작업한 내용을 구체적으로 작성해주세요.

- 마이페이지 카테고리 서버 데이터 가져와서 연동했어요

## 👾시연 화면 (option)  

|카테고리|  
|---|
|<img width="436" alt="image" src="https://github.com/user-attachments/assets/ca1cb8dc-8937-489b-8dde-5fa4e517cb00" />|


## Close 
close #259
