### PR TITLE
[#310] 오늘 미션 끝내기 여부 API 파라미터 추가 및 미션 완료 시 리롤 안되도록

### DIFF
--- a/core/designsystem/src/main/kotlin/com/dhc/designsystem/mission/DhcCardReRoll.kt
+++ b/core/designsystem/src/main/kotlin/com/dhc/designsystem/mission/DhcCardReRoll.kt
@@ -48,18 +48,21 @@ fun DhcCardReRoll(
     actionContent: @Composable () -> Unit,
     modifier:Modifier = Modifier,
     actionTopPadding: Dp = 0.dp,
-    content: @Composable () -> Unit
+    canEnabled: Boolean = true,
+    content: @Composable () -> Unit,
 ) {
     val density = LocalDensity.current
     var contextMenuWidth by remember { mutableFloatStateOf(0f) }
     var offsetX by remember { mutableFloatStateOf(if (isExpanded) contextMenuWidth else 0f) }
 
     val draggableState = rememberDraggableState { delta ->
-        if (!isExpanded) {
-            offsetX = (offsetX + delta).coerceIn(0f, contextMenuWidth - (12.dp.value * density.density))
-        } else {
-            if (delta < 0) {
-                offsetX = (offsetX + delta).coerceAtLeast(0f)
+        if(canEnabled) {
+            if (!isExpanded) {
+                offsetX = (offsetX + delta).coerceIn(0f, contextMenuWidth - (12.dp.value * density.density))
+            } else {
+                if (delta < 0) {
+                    offsetX = (offsetX + delta).coerceAtLeast(0f)
+                }
             }
         }
     }

--- a/data/src/main/kotlin/com/dhc/dhcandroid/model/HomeViewResponse.kt
+++ b/data/src/main/kotlin/com/dhc/dhcandroid/model/HomeViewResponse.kt
@@ -7,4 +7,5 @@ data class HomeViewResponse(
     val longTermMission: Mission = Mission(),
     val todayDailyMissionList: List<Mission> = emptyList(),
     val todayDailyFortune: DailyFortune = DailyFortune(),
+    val todayDone: Boolean = false
 )

--- a/presentation/home/src/main/java/com/dhc/home/HomeViewModel.kt
+++ b/presentation/home/src/main/java/com/dhc/home/HomeViewModel.kt
@@ -146,7 +146,7 @@ class HomeViewModel @Inject constructor(
     fun getHomeInfo() {
         viewModelScope.launch {
             val userId = userRepository.getUserId().firstOrNull() ?: return@launch
-            dhcRepository.getHomeView(userId = userId)
+            dhcRepository.getHomeView(userId = "685faf11de38af6c7bd9d25e")
                 .onSuccess { response ->
                     response ?: return@onSuccess
                     reduce { copy(homeInfo = HomeUiModel.from(response)) }
@@ -163,7 +163,7 @@ class HomeViewModel @Inject constructor(
         viewModelScope.launch {
             val userId = userRepository.getUserId().firstOrNull() ?: return@launch
             dhcRepository.changeMissionStatus(
-                userId = userId,
+                userId = "685faf11de38af6c7bd9d25e",
                 missionId = missionId,
                 toggleMissionRequest = missionStatusType.toToggleMissionRequest()
             ).onSuccess { response ->
@@ -283,13 +283,13 @@ class HomeViewModel @Inject constructor(
         viewModelScope.launch {
             val userId = userRepository.getUserId().firstOrNull() ?: return@launch
             dhcRepository.requestFinishTodayMissions(
-                userId = userId,
+                userId = "685faf11de38af6c7bd9d25e",
                 EndTodayMissionRequest(
                     date = todayStringFormat
                 )
             ).onSuccess {response ->
                 response ?: return@onSuccess
-                reduce { copy(todaySavedMoney = response.todaySavedMoney) }
+                reduce { copy(todaySavedMoney = response.todaySavedMoney, homeInfo = state.value.homeInfo.copy(todayDone = true)) }
                 updateMissionSuccessDialogState(isShowDialog = true)
 
             }.onFailure { code, message ->

--- a/presentation/home/src/main/java/com/dhc/home/HomeViewModel.kt
+++ b/presentation/home/src/main/java/com/dhc/home/HomeViewModel.kt
@@ -146,7 +146,7 @@ class HomeViewModel @Inject constructor(
     fun getHomeInfo() {
         viewModelScope.launch {
             val userId = userRepository.getUserId().firstOrNull() ?: return@launch
-            dhcRepository.getHomeView(userId = "685faf11de38af6c7bd9d25e")
+            dhcRepository.getHomeView(userId = userId)
                 .onSuccess { response ->
                     response ?: return@onSuccess
                     reduce { copy(homeInfo = HomeUiModel.from(response)) }
@@ -163,7 +163,7 @@ class HomeViewModel @Inject constructor(
         viewModelScope.launch {
             val userId = userRepository.getUserId().firstOrNull() ?: return@launch
             dhcRepository.changeMissionStatus(
-                userId = "685faf11de38af6c7bd9d25e",
+                userId = userId,
                 missionId = missionId,
                 toggleMissionRequest = missionStatusType.toToggleMissionRequest()
             ).onSuccess { response ->
@@ -283,7 +283,7 @@ class HomeViewModel @Inject constructor(
         viewModelScope.launch {
             val userId = userRepository.getUserId().firstOrNull() ?: return@launch
             dhcRepository.requestFinishTodayMissions(
-                userId = "685faf11de38af6c7bd9d25e",
+                userId = userId,
                 EndTodayMissionRequest(
                     date = todayStringFormat
                 )

--- a/presentation/home/src/main/java/com/dhc/home/main/HomeContract.kt
+++ b/presentation/home/src/main/java/com/dhc/home/main/HomeContract.kt
@@ -19,7 +19,6 @@ class HomeContract {
         val isShowFinishMissionChangeBottomSheet: Boolean = false,
         val selectedMissionInfo: SelectChangeMission = SelectChangeMission(),
         val homeInfo: HomeUiModel = HomeUiModel(),
-        val finishTodayMission: Boolean = false,
         val todaySavedMoney: String = "",
     ): UiState {
         val remainingMissionCount: Int

--- a/presentation/home/src/main/java/com/dhc/home/main/HomeMissionComponent.kt
+++ b/presentation/home/src/main/java/com/dhc/home/main/HomeMissionComponent.kt
@@ -53,6 +53,7 @@ fun SpendingHabitMission(
             missionUiModel = missionUiModel,
             onClickMissionChange = { onClickMissionChange(missionUiModel) },
             onExpandedChange = { onExpandedChange(it, missionUiModel.missionId)},
+            canEnabled = if(isFinishedTodayMission) false else !missionUiModel.isChecked,
             content = {
                 SpendingHabitMissionCard(
                     missionDday = missionUiModel.endDate,
@@ -97,6 +98,7 @@ fun MonetaryLuckyDailyMission(
                     missionUiModel = mission,
                     onClickMissionChange = { onClickMissionChange(mission) },
                     onExpandedChange = { onExpandedChange(it, mission.missionId)},
+                    canEnabled = if(isFinishedTodayMission) false else !mission.isChecked,
                     content = {
                         MoneyFortuneMissionCard(
                             isBlink = mission.isBlink,
@@ -124,15 +126,15 @@ private fun PreviewMonetaryLuckyDailyMission() {
                 missionUiModel = MissionUiModel(),
                 onExpandedChange = { _, _ -> },
                 onClickMissionChange = { _ -> },
-                onCheckChange = { _, _ ->},
+                onCheckChange = { _, _ -> },
                 onBlinkEnd = {}
             )
             Spacer(modifier = Modifier.height(24.dp))
             MonetaryLuckyDailyMission(
                 dailyMissionList = listOf(),
-                onClickMissionChange = {_ ->},
+                onClickMissionChange = {_ -> },
                 onBlinkEnd = {},
-                onExpandedChange = { _, _ ->},
+                onExpandedChange = { _, _ -> },
                 onCheckChange = { _, _ ->}
             )
         }

--- a/presentation/home/src/main/java/com/dhc/home/main/HomeScreen.kt
+++ b/presentation/home/src/main/java/com/dhc/home/main/HomeScreen.kt
@@ -116,7 +116,7 @@ fun HomeScreen(
             }
             SpendingHabitMission(
                 missionUiModel = state.homeInfo.longTermMission,
-                isFinishedTodayMission = state.finishTodayMission,
+                isFinishedTodayMission = state.homeInfo.todayDone,
                 onClickMissionChange = { mission -> eventHandler(HomeContract.Event.ClickMissionChange(
                     SelectChangeMission(
                         missionId = mission.missionId,
@@ -131,7 +131,7 @@ fun HomeScreen(
             Spacer(modifier = Modifier.height(24.dp))
             MonetaryLuckyDailyMission(
                 dailyMissionList = state.homeInfo.todayDailyMissionList,
-                isFinishedTodayMission = state.finishTodayMission,
+                isFinishedTodayMission = state.homeInfo.todayDone,
                 onClickMissionChange = { mission -> eventHandler(HomeContract.Event.ClickMissionChange(
                     SelectChangeMission(
                         missionId = mission.missionId,
@@ -146,14 +146,16 @@ fun HomeScreen(
             Spacer(modifier = Modifier.height(136.dp))
         }
 
-        DhcFloatingButton(
-            modifier = Modifier
-                .align(Alignment.BottomEnd)
-                .padding(bottom = 24.dp, end = 20.dp),
-            text = stringResource(R.string.finish_today_mission),
-            isEnabled = true,
-            onClick = { eventHandler(HomeContract.Event.ClickTodayMissionFinish) },
-        )
+        if(!state.homeInfo.todayDone) {
+            DhcFloatingButton(
+                modifier = Modifier
+                    .align(Alignment.BottomEnd)
+                    .padding(bottom = 24.dp, end = 20.dp),
+                text = stringResource(R.string.finish_today_mission),
+                isEnabled = true,
+                onClick = { eventHandler(HomeContract.Event.ClickTodayMissionFinish) },
+            )
+        }
     }
 }
 

--- a/presentation/home/src/main/java/com/dhc/home/main/MissionChange.kt
+++ b/presentation/home/src/main/java/com/dhc/home/main/MissionChange.kt
@@ -39,6 +39,7 @@ import com.dhc.designsystem.R as DR
 @Composable
 fun MissionCardReRoll(
     type: MissionType,
+    canEnabled: Boolean,
     missionChangeHeight: Int,
     missionUiModel: MissionUiModel,
     onClickMissionChange: () -> Unit,
@@ -65,6 +66,7 @@ fun MissionCardReRoll(
             isExpanded = it
             onExpandedChange(it)
         },
+        canEnabled = canEnabled,
         actionContent = {
             MissionChange(
                 modifier = Modifier
@@ -114,6 +116,7 @@ private fun PreviewMissionChange() {
         MissionCardReRoll(
             type = MissionType.LONG_TERM,
             missionChangeHeight = 0,
+            canEnabled = true,
             onClickMissionChange = {},
             missionUiModel = MissionUiModel(),
             onExpandedChange = {},

--- a/presentation/home/src/main/java/com/dhc/home/model/HomeUiModel.kt
+++ b/presentation/home/src/main/java/com/dhc/home/model/HomeUiModel.kt
@@ -5,13 +5,15 @@ import com.dhc.dhcandroid.model.HomeViewResponse
 data class HomeUiModel(
     val longTermMission: MissionUiModel = MissionUiModel(),
     val todayDailyMissionList: List<MissionUiModel> = emptyList(),
-    val todayDailyFortune: TodayDailyFortuneUiModel = TodayDailyFortuneUiModel()
+    val todayDailyFortune: TodayDailyFortuneUiModel = TodayDailyFortuneUiModel(),
+    val todayDone: Boolean = false
 ) {
     companion object {
         fun from(homeViewResponse: HomeViewResponse) = HomeUiModel(
             longTermMission = MissionUiModel.from(homeViewResponse.longTermMission),
             todayDailyMissionList = homeViewResponse.todayDailyMissionList.map { MissionUiModel.from(it) },
-            todayDailyFortune = TodayDailyFortuneUiModel.from(homeViewResponse.todayDailyFortune)
+            todayDailyFortune = TodayDailyFortuneUiModel.from(homeViewResponse.todayDailyFortune),
+            todayDone = homeViewResponse.todayDone
         )
     }
 }


### PR DESCRIPTION
## 개요
🔑**이슈 링크** : https://github.com/mash-up-kr/DHC-Android/issues/310


## 💻작업 내용  
 >작업한 내용을 구체적으로 작성해주세요.
- 홈 API에 오늘 미션끝냈는지 "todayDone" 추가 -> 플로팅 버튼 노출 조건 수정
- 미션 체크되거나 오늘 미션끝냈을 때 리롤 안되도록 조건 추가

## 🗣️To Reviwers  
> 리뷰어들이 중점적으로 봤으면 하는 부분이나, 전달하고 싶은 사항에 대해 작성해주세요.
- 돔황챠,,,처차차차차

## 👾시연 화면 (option)  

|체크ON/OFF|오늘 미션 끝냈을 때|  
|:---|---|
|<video src="https://github.com/user-attachments/assets/e6913b0a-b0cf-4eaa-8cec-b7cbdb35654e">|<video src ="https://github.com/user-attachments/assets/6a80b97b-084b-47ee-b01a-a7649874f99b">|


## Close 
close #310 
close #288 
