### PR TITLE
[#340] 홈 쪽 뒤집히고 나서의 딜레이 1.5초로 변경

### DIFF
--- a/presentation/home/src/main/java/com/dhc/home/HomeViewModel.kt
+++ b/presentation/home/src/main/java/com/dhc/home/HomeViewModel.kt
@@ -114,7 +114,7 @@ class HomeViewModel @Inject constructor(
             }
 
             is Event.FortuneCardFlipped -> {
-                delay(1000L)
+                delay(FLIPPED_TO_SUCCESS_DELAY_MS)
                 reduce { copy(homeState = HomeContract.HomeState.Success) }
             }
 
@@ -324,5 +324,6 @@ class HomeViewModel @Inject constructor(
     companion object {
         private const val POLLING_TRY_TIME = 5
         private const val POLLING_INTERVAL_TIME_MS = 5000L
+        private const val FLIPPED_TO_SUCCESS_DELAY_MS = 1500L
     }
 }


### PR DESCRIPTION
## 개요
🔑**이슈 링크** : https://github.com/mash-up-kr/DHC-Android/issues/340


## 💻작업 내용  
- 홈 쪽 뒤집히고 나서의 딜레이 1.5초로 변경
- 따로 딜레이 시간 변수로 분리


## 🗣️To Reviwers  
- 히히


## Close 
close #340 
