### PR TITLE
[#336] 인트로쪽 뒤로가기 버튼 아이콘 변경

### DIFF
--- a/core/designsystem/src/main/kotlin/com/dhc/designsystem/topbar/DhcBasicTopBar.kt
+++ b/core/designsystem/src/main/kotlin/com/dhc/designsystem/topbar/DhcBasicTopBar.kt
@@ -43,7 +43,7 @@ fun DhcBasicTopBar(
     ) {
         if (isShowBackButton) {
             Icon(
-                painter = painterResource(R.drawable.ico_arrow_left),
+                painter = painterResource(R.drawable.ico_chevron_left),
                 contentDescription = "Back",
                 tint = SurfaceColor.neutral50,
                 modifier = Modifier

--- a/core/designsystem/src/main/res/drawable/ico_chevron_left.xml
+++ b/core/designsystem/src/main/res/drawable/ico_chevron_left.xml
@@ -1,0 +1,10 @@
+<vector xmlns:android="http://schemas.android.com/apk/res/android"
+    android:width="24dp"
+    android:height="24dp"
+    android:viewportWidth="24"
+    android:viewportHeight="24">
+  <path
+      android:pathData="M15.707,5.293C16.098,5.683 16.098,6.317 15.707,6.707L10.414,12L15.707,17.293C16.098,17.683 16.098,18.317 15.707,18.707C15.317,19.098 14.683,19.098 14.293,18.707L8.293,12.707C7.902,12.317 7.902,11.683 8.293,11.293L14.293,5.293C14.683,4.902 15.317,4.902 15.707,5.293Z"
+      android:fillColor="#E6EDF8"
+      android:fillType="evenOdd"/>
+</vector>


### PR DESCRIPTION
## 개요
🔑**이슈 링크** : https://github.com/mash-up-kr/DHC-Android/issues/336


## 💻작업 내용  
- 뒤로가기 버튼 추가 및 적용


## 🗣️To Reviwers  
편-안


## 👾시연 화면 (option)  

|Before|After|
|-|-|
|<img width="419" height="938" alt="Image" src="https://github.com/user-attachments/assets/38f9a73e-91b5-4980-a415-4be459d603ba" />|<img width="419" height="934" alt="Image" src="https://github.com/user-attachments/assets/89ae0dfc-4033-47e4-96bf-bb6544e29129" />|


## Close 
close #336 
