### PR TITLE
[#319] 인트로 시작화면에서 다음으로 넘어갔다가 바로 뒤로가기로 되돌아오면 동영상 안보이는 이슈 수정

### DIFF
--- a/app/src/main/java/com/dhc/dhcandroid/navigation/DhcNavHost.kt
+++ b/app/src/main/java/com/dhc/dhcandroid/navigation/DhcNavHost.kt
@@ -1,6 +1,8 @@
 package com.dhc.dhcandroid.navigation
 
 import androidx.compose.animation.Crossfade
+import androidx.compose.animation.EnterTransition
+import androidx.compose.animation.ExitTransition
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -66,12 +68,18 @@ fun DhcNavHost(
             route = DhcRoute.INTRO.route,
             startDestination = DhcRoute.INTRO_START.route,
         ) {
-            composable(DhcRoute.INTRO_START.route) {
+            composable(
+                route = DhcRoute.INTRO_START.route,
+                exitTransition = { ExitTransition.None },
+            ) {
                 IntroRoute(
                     navigateToNextScreen = { navController.navigateTo(DhcRoute.INTRO_DESCRIPTION) },
                 )
             }
-            composable(DhcRoute.INTRO_DESCRIPTION.route) {
+            composable(
+                route = DhcRoute.INTRO_DESCRIPTION.route,
+                enterTransition = { EnterTransition.None },
+            ) {
                 IntroDescriptionRoute(
                     navigateToNextScreen = { navController.navigateTo(DhcRoute.INTRO_FORTUNE_CARD) },
                 )

--- a/presentation/intro/src/main/java/com/dhc/intro/start/IntroStartScreen.kt
+++ b/presentation/intro/src/main/java/com/dhc/intro/start/IntroStartScreen.kt
@@ -1,12 +1,5 @@
 package com.dhc.intro.start
 
-import android.view.TextureView
-import android.view.View
-import androidx.annotation.DrawableRes
-import androidx.annotation.OptIn
-import androidx.annotation.RawRes
-import androidx.compose.animation.AnimatedVisibility
-import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
@@ -26,9 +19,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.layout.ContentScale
-import androidx.compose.ui.platform.LocalContext
-import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview


### PR DESCRIPTION
## 개요
🔑**이슈 링크** : https://github.com/mash-up-kr/DHC-Android/issues/319


## 💻작업 내용  
- 애니메이션 때문에 다음으로 넘어갔다가 뒤로 바로 돌아오면 기존 Screen 을 재사용하는 것 같음.
- 근데 다음으로 누를 때 동영상 안보이게 state 처리 하였는데, 다음 누르고 바로 뒤로가기로 돌아와서 재사용하니까 동영상이 안보이는채로 멈추는 이슈가 발생함
- 그래서 그냥 애니메이션 읎애버림...

## 🗣️To Reviwers  
- navigation 골치아픈거 많네,,


## 👾시연 화면 (option)  

|Before|After|
|-|-|
|<video src="https://github.com/user-attachments/assets/6e44205c-41f4-43ef-b7ad-cfb29c9ef85a"/>|<video src="https://github.com/user-attachments/assets/092812d8-49b5-4a3c-86b9-edb3ce30f22d"/>|


## Close 
close #319 
