### PR TITLE
[#357] 운세상세의 팁 카드 양쪽 높이값이 다르면 동일하게 맞도록 변경

### DIFF
--- a/core/designsystem/src/main/kotlin/com/dhc/designsystem/tipcard/DhcTipCardGrid.kt
+++ b/core/designsystem/src/main/kotlin/com/dhc/designsystem/tipcard/DhcTipCardGrid.kt
@@ -2,8 +2,11 @@ package com.dhc.designsystem.tipcard
 
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.IntrinsicSize
 import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.fillMaxHeight
 import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
@@ -18,20 +21,20 @@ fun DhcTipCardGrid(
     modifier: Modifier = Modifier,
     cellCount: Int = 2,
 ) {
-    Row(
+    Column(
         modifier = modifier
             .fillMaxWidth()
             .padding(8.dp),
-        horizontalArrangement = Arrangement.spacedBy(12.dp)
+        verticalArrangement = Arrangement.spacedBy(10.dp),
     ) {
-        repeat(cellCount) { columnIndex ->
-            Column(
-                modifier = Modifier.weight(1f),
-                verticalArrangement = Arrangement.spacedBy(10.dp)
+        repeat(cellCount) { rowIndex ->
+            Row(
+                modifier = Modifier.fillMaxWidth().height(IntrinsicSize.Max),
+                horizontalArrangement = Arrangement.spacedBy(12.dp),
             ) {
-                for (rowIndex in 0 until tipCards.size / cellCount) {
-                    val itemIndex = rowIndex * cellCount + columnIndex
-                    DhcTipCard(tipCards[itemIndex], Modifier.fillMaxWidth())
+                for (columnIndex in 0 until tipCards.size / cellCount) {
+                    val itemIndex = columnIndex * cellCount + rowIndex
+                    DhcTipCard(tipCards[itemIndex], Modifier.weight(1f).fillMaxHeight())
                 }
             }
         }
@@ -47,7 +50,7 @@ fun PreviewDhcTipCardLazyGrid() {
         DhcTipCardGrid(
             tipCards = listOf(
                 TipCardModel(
-                    title = "오늘의 추천 메뉴",
+                    title = "오늘의 추천 메뉴 추천 메뉴",
                     icon = ImageResource.Url("https://foodish-api.com/images/pizza/pizza80.jpg"),
                     color = null,
                     cont = "치킨이닭"


### PR DESCRIPTION
## 개요
🔑**이슈 링크** : https://github.com/mash-up-kr/DHC-Android/issues/357


## 💻작업 내용  
- 운세상세의 팁 카드 양쪽 높이값이 다르면 동일하게 맞도록 변경


## 🗣️To Reviwers  
- 흠

## 👾시연 화면 (option)  

|Before|After|  
|---|---|
|<img width="236" alt="스크린샷 2025-07-07 오후 10 16 02" src="https://github.com/user-attachments/assets/a29cacdd-0c90-4213-ba1a-a58591adf02f" />|<img width="239" alt="스크린샷 2025-07-07 오후 10 19 21" src="https://github.com/user-attachments/assets/62c78ffc-0528-495c-b970-b6e5eb2f338a" />|




## Close 
close #357
