### PR TITLE
[#324] 홈화면 다른 탭 이동 시 상태 초기화 되는 이슈 수정

### DIFF
--- a/app/src/main/java/com/dhc/dhcandroid/navigation/DhcNavHost.kt
+++ b/app/src/main/java/com/dhc/dhcandroid/navigation/DhcNavHost.kt
@@ -122,8 +122,9 @@ fun DhcNavHost(
                 navigateToInitialScreen = { navController.navigateToIntroPageWithClearStack() },
             )
         }
-        composable(DhcRoute.MAIN_HOME.route) {
+        composable(DhcRoute.MAIN_HOME.route) { navBackStackEntry ->
             HomeRoute(
+                navBackStackEntry = navBackStackEntry,
                 navigateToMission = { navController.navigateToMission() },
                 navigateToMonetaryLuckDetail = { navController.navigateTo(DhcRoute.HOME_MONETARY_DETAIL) },
             )

--- a/presentation/home/src/main/java/com/dhc/home/HomeRoute.kt
+++ b/presentation/home/src/main/java/com/dhc/home/HomeRoute.kt
@@ -21,6 +21,7 @@ import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import androidx.navigation.NavBackStackEntry
 import com.dhc.designsystem.DhcSnackBar
 import com.dhc.designsystem.GradientColor
 import com.dhc.designsystem.SnackBarContent
@@ -37,9 +38,10 @@ import kotlinx.coroutines.launch
 
 @Composable
 fun HomeRoute(
+    navBackStackEntry: NavBackStackEntry,
     navigateToMission: () -> Unit,
     navigateToMonetaryLuckDetail: () -> Unit,
-    viewModel: HomeViewModel = hiltViewModel()
+    viewModel: HomeViewModel = hiltViewModel(navBackStackEntry)
 ) {
     val state by viewModel.state.collectAsStateWithLifecycle()
     val snackBarHostState by remember { mutableStateOf(SnackbarHostState()) }


### PR DESCRIPTION
## 개요
🔑**이슈 링크** : https://github.com/mash-up-kr/DHC-Android/issues/324


## 💻작업 내용  
 >작업한 내용을 구체적으로 작성해주세요.
- 홈화면 다른 탭 이동 시 상태 초기화 되는 이슈 수정하였슴당~!

## 🗣️To Reviwers  
> 리뷰어들이 중점적으로 봤으면 하는 부분이나, 전달하고 싶은 사항에 대해 작성해주세요.
- 아자자.

## 👾시연 화면 (option)  

|기능A 구현|기능B 구현|  
|:---|---|
|||


## Close 
close #324 
