### PR TITLE
[#356] 미션 내용이 두 줄 이상이 되면 짤리는 현상 수정

### DIFF
--- a/core/designsystem/src/main/kotlin/com/dhc/designsystem/mission/MoneyFortuneMissionCard.kt
+++ b/core/designsystem/src/main/kotlin/com/dhc/designsystem/mission/MoneyFortuneMissionCard.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
@@ -53,10 +54,10 @@ fun MoneyFortuneMissionCard(
             Row(
                 modifier = Modifier
                     .fillMaxWidth()
-                    .weight(1f),
+                    .weight(1f)
+                    .padding(vertical = 20.dp),
             ) {
                 DhcBadge(
-                    modifier = Modifier.height(24.dp),
                     text = missionMode,
                     type = BadgeType.Level(isEnabled = isFinishedTodayMission.not())
                 )

--- a/core/designsystem/src/main/kotlin/com/dhc/designsystem/mission/SpendingHabitMissionCard.kt
+++ b/core/designsystem/src/main/kotlin/com/dhc/designsystem/mission/SpendingHabitMissionCard.kt
@@ -59,7 +59,7 @@ fun SpendingHabitMissionCard(
             onBlinkEnd = onBlinkEnd,
             content = {
                 Row(
-                    modifier = Modifier.fillMaxWidth().weight(1f),
+                    modifier = Modifier.fillMaxWidth().weight(1f).padding(vertical = 20.dp),
                 ) {
                     DhcBadge(
                         text = missionDday,
@@ -69,7 +69,7 @@ fun SpendingHabitMissionCard(
                     Text(
                         text = missionTitle,
                         style = DhcTypoTokens.Body3,
-                        color = missionColor
+                        color = missionColor,
                     )
                     Spacer(modifier = Modifier.width(16.dp))
                 }


### PR DESCRIPTION
## 개요
🔑**이슈 링크** : https://github.com/mash-up-kr/DHC-Android/issues/356


## 💻작업 내용  
- 강제 높이지정 제거
- 내용물에 verticalPadding 추가


## 🗣️To Reviwers  
- 흠

## 👾시연 화면 (option)  

|Before|After|  
|---|---|
|<img width="236" alt="스크린샷 2025-07-07 오후 10 28 53" src="https://github.com/user-attachments/assets/af88f7ec-5fe8-4ad8-8edd-3f3d67ab6c23" />|<img width="238" alt="스크린샷 2025-07-07 오후 10 47 32" src="https://github.com/user-attachments/assets/52823fe6-5c7f-462d-9d3b-4a80712f087c" />|



## Close 
close #356 
