### PR TITLE
[#362] MissionCategoryResponse 필드명 변경

### DIFF
--- a/data/src/main/kotlin/com/dhc/dhcandroid/model/MissionCategoriesResponse.kt
+++ b/data/src/main/kotlin/com/dhc/dhcandroid/model/MissionCategoriesResponse.kt
@@ -11,5 +11,5 @@ data class MissionCategoriesResponse(
 data class MissionCategoryResponse(
     val name: MissionCategory = MissionCategory.UNKNOWN,
     val displayName: String = "",
-    val imageUrl: String = "",
+    val image: String = "",
 )

--- a/presentation/intro/src/main/java/com/dhc/intro/category/IntroCategoryViewModel.kt
+++ b/presentation/intro/src/main/java/com/dhc/intro/category/IntroCategoryViewModel.kt
@@ -27,7 +27,7 @@ class IntroCategoryViewModel @Inject constructor(
                 CategoryItem(
                     name = it.name,
                     displayName = it.displayName,
-                    imageUrl = it.imageUrl
+                    imageUrl = it.image
                 )
             } ?: emptyList()
 

--- a/presentation/mypage/src/main/kotlin/com/dhc/mypage/model/MissionCategoryUiModel.kt
+++ b/presentation/mypage/src/main/kotlin/com/dhc/mypage/model/MissionCategoryUiModel.kt
@@ -13,7 +13,7 @@ data class MissionCategoryUiModel(
             MissionCategoryUiModel(
                 name = missionCategoryResponse.name,
                 displayName = missionCategoryResponse.displayName,
-                imageUrl = missionCategoryResponse.imageUrl
+                imageUrl = missionCategoryResponse.image
             )
     }
 }


### PR DESCRIPTION
## 개요
🔑**이슈 링크** : https://github.com/mash-up-kr/DHC-Android/issues/362


## 💻작업 내용  
- 인트로쪽 카테고리 아이콘 보이도록 필드명 수정함
- 마이페이지 UserId 꽉찼길래 padding 좀 넣어주어보았음

## 🗣️To Reviwers  
> 리뷰어들이 중점적으로 봤으면 하는 부분이나, 전달하고 싶은 사항에 대해 작성해주세요.


## 👾시연 화면 (option)  

|인트로|마이페이지|  
|---|---|
|<img width="237" alt="스크린샷 2025-07-07 오후 11 18 31" src="https://github.com/user-attachments/assets/0febba2a-52aa-48ec-bfa2-0cce8b169921" />|<img width="240" alt="스크린샷 2025-07-07 오후 11 19 49" src="https://github.com/user-attachments/assets/0fef036e-e3e7-438f-a73a-f9419e77f9fa" />|


## Close 
close #362 
