### PR TITLE
[#378] Intro 운세상세 color 안보여줘야 하는 부분 null 처리

### DIFF
--- a/presentation/intro/src/main/java/com/dhc/intro/fortunedetail/IntroFortuneDetailViewModel.kt
+++ b/presentation/intro/src/main/java/com/dhc/intro/fortunedetail/IntroFortuneDetailViewModel.kt
@@ -38,7 +38,7 @@ class IntroFortuneDetailViewModel @Inject constructor(
                     TipCardModel(
                         title = "오늘의 추천 메뉴",
                         icon = ImageResource.Drawable(com.dhc.designsystem.R.drawable.ico_knife),
-                        color = "#D7E1EE",
+                        color = null,
                         cont = "카레"
                     ),
                     TipCardModel(
@@ -50,7 +50,7 @@ class IntroFortuneDetailViewModel @Inject constructor(
                     TipCardModel(
                         title = "피해야 할 음식",
                         icon = ImageResource.Drawable(com.dhc.designsystem.R.drawable.ico_green_face),
-                        color = "#D7E1EE",
+                        color = null,
                         cont = "치킨, 닭"
                     ),
                     TipCardModel(


### PR DESCRIPTION
## 개요
🔑**이슈 링크** : https://github.com/mash-up-kr/DHC-Android/issues/378


## 💻작업 내용  
- o 안보이게 처리 필요한거 null 처리해야함


## 🗣️To Reviwers  
- 흠

## 👾시연 화면 (option)  

|Before|After|  
|---|---|
|<img width="225" src="https://github.com/user-attachments/assets/004957d7-cd18-4a71-bbb8-f38650a08fa9"/>|<img width="225" alt="스크린샷 2025-07-10 오전 12 41 29" src="https://github.com/user-attachments/assets/f5745f05-1586-49d6-a7a6-3ed8f8bb72f1" />|



## Close 
close #378 
