### PR TITLE
[#393] 바텀바에 고정값 height 있는거 빼버리기

### DIFF
--- a/app/src/main/java/com/dhc/dhcandroid/navigation/DhcApp.kt
+++ b/app/src/main/java/com/dhc/dhcandroid/navigation/DhcApp.kt
@@ -6,7 +6,6 @@ import androidx.compose.animation.fadeOut
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.navigationBarsPadding
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.statusBarsPadding
@@ -17,7 +16,6 @@ import androidx.compose.runtime.derivedStateOf
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.unit.dp
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavHostController
@@ -58,8 +56,7 @@ fun DhcApp(
                 navigateToRoute = { navController.navigateToBottomNavigation(DhcRoute.fromName(it)) },
                 modifier = Modifier
                     .fillMaxWidth()
-                    .navigationBarsPadding()
-                    .height(60.dp),
+                    .navigationBarsPadding(),
             )
         },
         containerColor = colors.background.backgroundMain,


### PR DESCRIPTION
## 개요
🔑**이슈 링크** : https://github.com/mash-up-kr/DHC-Android/issues/393


## 💻작업 내용  
- 바텀바에 고정값 height 있는거 빼버리기
- 근데,, 바텀바인데 왜 저게 들어가있었지..? 흠

## 🗣️To Reviwers  
- ㅠㅠ

## 👾시연 화면 (option)  

|Before|After|  
|---|---|
|<img width="221" alt="image" src="https://gi#393 .com/user-attachments/assets/70a02b1c-058e-45d4-b855-a4bd0cb220d9" />|<img width="225" alt="스크린샷 2025-07-10 오전 12 41 29" src="https://github.com/user-attachments/assets/f5745f05-1586-49d6-a7a6-3ed8f8bb72f1" />|



## Close 
close #393
