### PR TITLE
[#320] 토스트 이전꺼 취소하고 뜨도록 수정

### DIFF
--- a/core/designsystem/src/main/kotlin/com/dhc/designsystem/snackbar/DhcSnackBar.kt
+++ b/core/designsystem/src/main/kotlin/com/dhc/designsystem/snackbar/DhcSnackBar.kt
@@ -1,4 +1,4 @@
-package com.dhc.designsystem
+package com.dhc.designsystem.snackbar
 
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Row
@@ -14,9 +14,12 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.dhc.designsystem.DhcTheme
+import com.dhc.designsystem.DhcTypoTokens
+import com.dhc.designsystem.LocalDhcColors
+import com.dhc.designsystem.SurfaceColor
 import com.dhc.designsystem.check.DhcCheck
 import com.dhc.designsystem.check.model.DhcCheckStyle
 

--- a/core/designsystem/src/main/kotlin/com/dhc/designsystem/snackbar/SnackBarUtil.kt
+++ b/core/designsystem/src/main/kotlin/com/dhc/designsystem/snackbar/SnackBarUtil.kt
@@ -1,0 +1,11 @@
+package com.dhc.designsystem.snackbar
+
+import androidx.compose.material3.SnackbarHostState
+
+
+suspend fun SnackbarHostState.showImmediately(
+    message: String,
+) {
+    currentSnackbarData?.dismiss()
+    showSnackbar(message)
+}

--- a/presentation/home/src/main/java/com/dhc/home/HomeRoute.kt
+++ b/presentation/home/src/main/java/com/dhc/home/HomeRoute.kt
@@ -45,6 +45,7 @@ fun HomeRoute(
                 is HomeContract.SideEffect.NavigateToMonetaryDetailScreen -> navigateToMonetaryLuckDetail()
                 is HomeContract.SideEffect.NavigateToMission -> navigateToMission()
                 is HomeContract.SideEffect.ShowToast -> {
+                    snackBarHostState.currentSnackbarData?.dismiss()
                     scope.launch {
                         snackBarHostState.showSnackbar(message = sideEffect.msg )
                     }

--- a/presentation/home/src/main/java/com/dhc/home/HomeRoute.kt
+++ b/presentation/home/src/main/java/com/dhc/home/HomeRoute.kt
@@ -15,8 +15,9 @@ import androidx.compose.ui.Modifier
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.navigation.NavBackStackEntry
-import com.dhc.designsystem.DhcSnackBar
-import com.dhc.designsystem.SnackBarContent
+import com.dhc.designsystem.snackbar.DhcSnackBar
+import com.dhc.designsystem.snackbar.SnackBarContent
+import com.dhc.designsystem.snackbar.showImmediately
 import com.dhc.home.main.FinishMissionChangeBottomSheet
 import com.dhc.home.main.HomeContract
 import com.dhc.home.main.HomeFlipCardScreen
@@ -47,7 +48,7 @@ fun HomeRoute(
                 is HomeContract.SideEffect.ShowToast -> {
                     snackBarHostState.currentSnackbarData?.dismiss()
                     scope.launch {
-                        snackBarHostState.showSnackbar(message = sideEffect.msg )
+                        snackBarHostState.showImmediately(sideEffect.msg)
                     }
                 }
             }


### PR DESCRIPTION
## 개요
🔑**이슈 링크** : https://github.com/mash-up-kr/DHC-Android/issues/320


## 💻작업 내용  
 >작업한 내용을 구체적으로 작성해주세요.
- 토스트가 취소되고 다음꺼가 바로떠요~!

## 🗣️To Reviwers  
> 리뷰어들이 중점적으로 봤으면 하는 부분이나, 전달하고 싶은 사항에 대해 작성해주세요.
![common-20](https://github.com/user-attachments/assets/1b11bb16-33c4-42f9-94eb-c351ee4546d6)


## 👾시연 화면 (option)  

|기능A 구현|  
|:---|
|https://github.com/user-attachments/assets/ed49a9d8-5bc5-4813-bff5-777a8725dfb5|


## Close 
close #320
