### PR TITLE
[#377] 인트로 시작화면 동영상 실행될때 바탕화면 나갔다오면 영상 꺼짐 이슈

### DIFF
--- a/presentation/intro/src/main/java/com/dhc/intro/start/IntroStartRoute.kt
+++ b/presentation/intro/src/main/java/com/dhc/intro/start/IntroStartRoute.kt
@@ -15,12 +15,10 @@ fun IntroRoute(
     navigateToNextScreen: () -> Unit,
     viewModel: IntroStartViewModel = hiltViewModel(),
 ) {
-    var isVideoShow by remember { mutableStateOf(true) }
     LaunchedEffect(Unit) {
         viewModel.sideEffect.collect { sideEffect ->
             when (sideEffect) {
                 IntroStartContract.SideEffect.NavigateToNextScreen -> {
-                    isVideoShow = false
                     navigateToNextScreen()
                 }
             }
@@ -29,7 +27,6 @@ fun IntroRoute(
 
     IntroStartScreen(
         eventHandler = viewModel::sendEvent,
-        isVideoShow = isVideoShow,
         modifier = Modifier.fillMaxSize(),
     )
 }

--- a/presentation/intro/src/main/java/com/dhc/intro/start/IntroStartScreen.kt
+++ b/presentation/intro/src/main/java/com/dhc/intro/start/IntroStartScreen.kt
@@ -36,7 +36,6 @@ import com.dhc.presentation.mvi.EventHandler
 @Composable
 fun IntroStartScreen(
     eventHandler: EventHandler<IntroStartContract.Event>,
-    isVideoShow: Boolean,
     modifier: Modifier = Modifier,
 ) {
     val colors = LocalDhcColors.current
@@ -49,7 +48,6 @@ fun IntroStartScreen(
                 .fillMaxWidth()
                 .align(Alignment.BottomCenter)
                 .aspectRatio(375f / 672f)
-                .graphicsLayer { alpha = if (isVideoShow) 1f else 0f }
         )
         Column(
             modifier = Modifier
@@ -98,7 +96,6 @@ private fun IntroStartScreenPreview() {
     DhcTheme {
         IntroStartScreen(
             eventHandler = {},
-            isVideoShow = true,
             modifier = Modifier,
         )
     }


### PR DESCRIPTION
## 개요
🔑**이슈 링크** : https://github.com/mash-up-kr/DHC-Android/issues/377


## 💻작업 내용  
- 인트로 시작화면 동영상 실행될때 바탕화면 나갔다오면 영상 꺼짐 이슈
- exoplayer 를 background 로 나가서 release() 시켰던 것 다시 데려와서 보여주려고 하다보니 생긴 오류인 것 같음
- state 로 만들고, Foreground 로 올라올 때 마다 다시 초기화하도록 하여 해결하였슴다

## 🗣️To Reviwers  
- 아따 영상 어렵네,,,
 

## 👾시연 화면 (option)  

|Before|AFter|  
|---|---|
|<video src="https://github.com/user-attachments/assets/e3670d40-8cdd-4997-a7da-e0c7e939a25e"/>|<video src="https://github.com/user-attachments/assets/1cd4173c-6243-453c-b3a4-8538d9f28b16"/>|





## Close 
close #377 
