### PR TITLE
[#412] 미션상세 이동 시 크래시나는 현상 수정

### DIFF
--- a/core/common/src/main/kotlin/com/dhc/common/StringExt.kt
+++ b/core/common/src/main/kotlin/com/dhc/common/StringExt.kt
@@ -1,0 +1,13 @@
+package com.dhc.common
+
+import kotlin.contracts.ExperimentalContracts
+import kotlin.contracts.contract
+
+@OptIn(ExperimentalContracts::class)
+fun String?.isNotNullOrEmpty(): Boolean {
+    contract {
+        returns(true) implies (this@isNotNullOrEmpty != null)
+    }
+
+    return isNullOrEmpty().not()
+}

--- a/core/designsystem/src/main/kotlin/com/dhc/designsystem/tipcard/DhcTipCard.kt
+++ b/core/designsystem/src/main/kotlin/com/dhc/designsystem/tipcard/DhcTipCard.kt
@@ -160,7 +160,7 @@ fun TipCardContent(
         Text(
             text = content,
             style = DhcTypoTokens.TitleH3,
-            color = if(color.isNotNullOrEmpty()) hexToColor(color) else dhcColor.text.textBodyPrimary,
+            color = if (color.isNotNullOrEmpty()) hexToColor(color) else dhcColor.text.textBodyPrimary,
             textAlign = TextAlign.Center,
         )
     }

--- a/core/designsystem/src/main/kotlin/com/dhc/designsystem/tipcard/DhcTipCard.kt
+++ b/core/designsystem/src/main/kotlin/com/dhc/designsystem/tipcard/DhcTipCard.kt
@@ -27,6 +27,7 @@ import androidx.compose.ui.unit.dp
 import coil3.compose.AsyncImage
 import com.dhc.common.ImageResource
 import com.dhc.common.hexToColor
+import com.dhc.common.isNotNullOrEmpty
 import com.dhc.designsystem.DhcTheme
 import com.dhc.designsystem.DhcTypoTokens
 import com.dhc.designsystem.LocalDhcColors
@@ -146,7 +147,7 @@ fun TipCardContent(
         modifier = modifier.wrapContentSize(),
         verticalAlignment = Alignment.CenterVertically
     ) {
-        color?.let {
+        if (color.isNotNullOrEmpty()) {
             Canvas(modifier = Modifier.size(8.dp)) {
                 drawCircle(
                     color = hexToColor(color),
@@ -155,10 +156,11 @@ fun TipCardContent(
             }
             Spacer(modifier = Modifier.width(8.dp))
         }
+
         Text(
             text = content,
             style = DhcTypoTokens.TitleH3,
-            color = if(color != null) hexToColor(color) else dhcColor.text.textBodyPrimary,
+            color = if(color.isNotNullOrEmpty()) hexToColor(color) else dhcColor.text.textBodyPrimary,
             textAlign = TextAlign.Center,
         )
     }


### PR DESCRIPTION
## 개요
🔑**이슈 링크** : https://github.com/mash-up-kr/DHC-Android/issues/412


## 💻작업 내용  
- color 값이 반 문자열이어도 null 과 동일하게 동작하게 수정
- color 값이 "" 이서서 파싱안된다는 오류 뜬거였음


## 🗣️To Reviwers  
-

## 👾시연 화면 (option)  

|기능 구현|  
|---|
|<video src="https://github.com/user-attachments/assets/c18934fb-219a-4bf6-9648-b9f7692868e3"/>|





## Close 
close #412 
