### PR TITLE
[#422] 앱 초기화버튼 리플영역 수정

### DIFF
--- a/presentation/mypage/src/main/kotlin/com/dhc/mypage/ui/settinglist/SettingList.kt
+++ b/presentation/mypage/src/main/kotlin/com/dhc/mypage/ui/settinglist/SettingList.kt
@@ -1,6 +1,7 @@
 package com.dhc.mypage.ui.settinglist
 
 import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.padding
@@ -23,17 +24,26 @@ internal fun SettingList(
     val colors = LocalDhcColors.current
 
     Column(
-        modifier = modifier
-            .background(color = SurfaceColor.neutral700, shape = RoundedCornerShape(12.dp))
-            .padding(horizontal = 16.dp, vertical = 12.dp),
+        modifier = modifier.background(color = SurfaceColor.neutral700, shape = RoundedCornerShape(12.dp)),
     ) {
         settingItems.forEachIndexed { index, settingItem ->
             when (settingItem) {
                 is SettingItem.Normal -> {
-                    SettingNormalItem(item = settingItem)
+                    SettingNormalItem(
+                        item = settingItem,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .clickable { settingItem.onClick() }
+                            .padding(all = 16.dp),
+                    )
                 }
                 is SettingItem.Toggle -> {
-                    SettingToggleItem(item = settingItem)
+                    SettingToggleItem(
+                        item = settingItem,
+                        modifier = Modifier
+                            .fillMaxWidth()
+                            .padding(all = 16.dp),
+                    )
                 }
             }
             if (index < settingItems.lastIndex) {

--- a/presentation/mypage/src/main/kotlin/com/dhc/mypage/ui/settinglist/SettingNormalItem.kt
+++ b/presentation/mypage/src/main/kotlin/com/dhc/mypage/ui/settinglist/SettingNormalItem.kt
@@ -25,9 +25,7 @@ internal fun SettingNormalItem(
     val colors = LocalDhcColors.current
 
     Row(
-        modifier = modifier
-            .clickable { item.onClick() }
-            .padding(vertical = 16.dp),
+        modifier = modifier,
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(8.dp),
     ) {

--- a/presentation/mypage/src/main/kotlin/com/dhc/mypage/ui/settinglist/SettingToggleItem.kt
+++ b/presentation/mypage/src/main/kotlin/com/dhc/mypage/ui/settinglist/SettingToggleItem.kt
@@ -4,6 +4,7 @@ import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -32,6 +33,7 @@ internal fun SettingToggleItem(
         Image(
             painter = painterResource(item.iconRes),
             contentDescription = "sign out",
+            modifier = Modifier.size(20.dp),
         )
         Text(
             modifier = Modifier.weight(1f),

--- a/presentation/mypage/src/main/kotlin/com/dhc/mypage/ui/settinglist/SettingToggleItem.kt
+++ b/presentation/mypage/src/main/kotlin/com/dhc/mypage/ui/settinglist/SettingToggleItem.kt
@@ -25,8 +25,7 @@ internal fun SettingToggleItem(
     val colors = LocalDhcColors.current
 
     Row(
-        modifier = modifier
-            .padding(vertical = 16.dp),
+        modifier = modifier,
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(8.dp),
     ) {


### PR DESCRIPTION
## 개요
🔑**이슈 링크** : https://github.com/mash-up-kr/DHC-Android/issues/422 


## 💻작업 내용  
- 리플영역 수정했슴당
- 그냥 Modifier 를 바깥으로 다 빼버렸어용
- 이미지 20.dp 로 고정값도 추가해줬어용


## 🗣️To Reviwers  
- 흠

## 👾시연 화면 (option)  

|Before|After|  
|---|---|
|<video src="https://github.com/user-attachments/assets/68d02dca-a463-406f-9103-b5867ee8e4bc"/>|<video src="https://github.com/user-attachments/assets/cc2258c3-9eb1-40ad-9c0d-294141065363"/>|



## Close 
close #422 
