### PR TITLE
[#429] 홈화면 - 카드 텍스트, 이미지 겹치는 현상 수정

### DIFF
--- a/core/designsystem/src/main/kotlin/com/dhc/designsystem/fortunecard/DhcFortuneCard.kt
+++ b/core/designsystem/src/main/kotlin/com/dhc/designsystem/fortunecard/DhcFortuneCard.kt
@@ -154,13 +154,13 @@ fun DhcFortuneCardInternal(
             horizontalAlignment = Alignment.CenterHorizontally,
         ) {
             Text(
-                text = title,
+                text = description,
                 style = DhcTypoTokens.TitleH8.copy(brush = GradientColor.textGradient02),
                 textAlign = TextAlign.Center,
             )
             Text(
                 modifier = Modifier.padding(bottom = 8.dp),
-                text = description,
+                text = title,
                 style = DhcTypoTokens.TitleH6,
                 textAlign = TextAlign.Center,
                 color = colors.text.textBodyPrimary,
@@ -172,8 +172,8 @@ fun DhcFortuneCardInternal(
 private class DhcFortuneCardPreviewProvider : PreviewParameterProvider<DhcFortuneCardPreviewProvider.Parameter> {
     override val values = sequenceOf(
         Parameter(
-            title = "최고의 날",
-            description = "네잎클로버",
+            title = "네잎클로버",
+            description = "최고의 날",
         ),
         Parameter(
             title = "카드 뒷면",

--- a/presentation/home/src/main/java/com/dhc/home/main/HomeScreen.kt
+++ b/presentation/home/src/main/java/com/dhc/home/main/HomeScreen.kt
@@ -2,19 +2,14 @@ package com.dhc.home.main
 
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.ScrollState
-import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxSize
-import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.statusBars
 import androidx.compose.foundation.rememberScrollState
 import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.Text
@@ -22,7 +17,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -33,7 +27,6 @@ import com.dhc.designsystem.SurfaceColor
 import com.dhc.designsystem.floatingButton.DhcFloatingButton
 import com.dhc.designsystem.fortunecard.DhcFortuneCard
 import com.dhc.home.R
-import com.dhc.designsystem.R as DR
 import com.dhc.home.model.SelectChangeMission
 import com.dhc.presentation.mvi.EventHandler
 
@@ -74,7 +67,7 @@ fun HomeScreen(
                         .align(Alignment.CenterHorizontally)
                         .graphicsLayer(rotationZ = 4f)
                         .clickable { eventHandler(HomeContract.Event.ClickFortuneCard) },
-                    title = state.homeInfo.todayDailyFortune.fortuneTitle,
+                    title = state.homeInfo.todayDailyFortune.fortuneCardTitle,
                     description = state.homeInfo.todayDailyFortune.fortuneCardSubTitle,
                     imageUrl = state.homeInfo.todayDailyFortune.fortuneCardImage,
                 )


### PR DESCRIPTION
## 개요
🔑**이슈 링크** : https://github.com/mash-up-kr/DHC-Android/issues/429


## 💻작업 내용  
 >작업한 내용을 구체적으로 작성해주세요.

- 홈화면 - 카드 텍스트, 이미지 겹치는 현상 수정

## 👾시연 화면 (option)  
|After|
|---|
|<img width="439" height="904" alt="image" src="https://github.com/user-attachments/assets/c143d40b-0712-433f-b395-e5c16fa513bd" />|


## Close 
close #429
