### PR TITLE
[#433] 금전운 상세보기 데이터 비어 있는 현상 수정

### DIFF
--- a/core/designsystem/src/main/kotlin/com/dhc/designsystem/tipcard/DhcTipCardGrid.kt
+++ b/core/designsystem/src/main/kotlin/com/dhc/designsystem/tipcard/DhcTipCardGrid.kt
@@ -22,9 +22,7 @@ fun DhcTipCardGrid(
     cellCount: Int = 2,
 ) {
     Column(
-        modifier = modifier
-            .fillMaxWidth()
-            .padding(8.dp),
+        modifier = modifier.fillMaxWidth(),
         verticalArrangement = Arrangement.spacedBy(10.dp),
     ) {
         repeat(cellCount) { rowIndex ->

--- a/data/src/main/kotlin/com/dhc/dhcandroid/model/DailyFortuneResponse.kt
+++ b/data/src/main/kotlin/com/dhc/dhcandroid/model/DailyFortuneResponse.kt
@@ -9,7 +9,5 @@ data class DailyFortuneResponse(
     val totalScore: Int = 0,
     val positiveScore: Int = 0,
     val negativeScore: Int = 0,
-    val fortuneCardImage: String = "",
-    val fortuneCardTitle: String = "",
-    val fortuneCardSubTitle: String = ""
+    val cardInfo: FortuneCardInfo = FortuneCardInfo(),
 )

--- a/data/src/main/kotlin/com/dhc/dhcandroid/model/FortuneResponse.kt
+++ b/data/src/main/kotlin/com/dhc/dhcandroid/model/FortuneResponse.kt
@@ -20,14 +20,14 @@ enum class FortuneColor {
 
 @Serializable
 data class FortuneCardInfo(
-    val imageURL: String = "",
+    val image: String = "",
     val title: String = "",
     val subTitle: String = "",
 )
 
 @Serializable
 data class FortuneTips(
-    val imageURL: String = "",
+    val image: String = "",
     val title: String = "",
     val description: String = "",
     val hexColor: String? = null

--- a/presentation/home/src/main/java/com/dhc/home/detail/utils/Extensions.kt
+++ b/presentation/home/src/main/java/com/dhc/home/detail/utils/Extensions.kt
@@ -19,13 +19,13 @@ internal fun FortuneResponse.toMonetaryLuckInfo() = MonetaryLuckInfo(
     fortuneCard = FortuneCard(
         title = cardInfo.title,
         message = cardInfo.subTitle,
-        image = ImageResource.Url(cardInfo.imageURL),
+        image = ImageResource.Url(cardInfo.image),
     ),
     monetaryDetail = this.fortuneDetail,
     todayTips = tips.map { tip ->
         TipCardModel(
             title = tip.title,
-            icon = ImageResource.Url(tip.imageURL),
+            icon = ImageResource.Url(tip.image),
             cont = tip.description,
             color = tip.hexColor,
         )

--- a/presentation/home/src/main/java/com/dhc/home/model/TodayDailyFortuneUiModel.kt
+++ b/presentation/home/src/main/java/com/dhc/home/model/TodayDailyFortuneUiModel.kt
@@ -15,9 +15,9 @@ data class TodayDailyFortuneUiModel(
             date = fortune.date,
             fortuneTitle = fortune.fortuneTitle,
             score = fortune.totalScore,
-            fortuneCardImage = fortune.fortuneCardImage,
-            fortuneCardTitle = fortune.fortuneCardTitle,
-            fortuneCardSubTitle = fortune.fortuneCardSubTitle
+            fortuneCardImage = fortune.cardInfo.image,
+            fortuneCardTitle = fortune.cardInfo.title,
+            fortuneCardSubTitle = fortune.cardInfo.subTitle,
         )
     }
 }


### PR DESCRIPTION
## 개요
🔑**이슈 링크** : https://github.com/mash-up-kr/DHC-Android/issues/433


## 💻작업 내용  
 >작업한 내용을 구체적으로 작성해주세요.

- 변경된 데이터 모델 반영

## 👾시연 화면 (option)  

|금전운 상세 보기|
|---|
|<img width="391" height="800" alt="image" src="https://github.com/user-attachments/assets/0aafb448-4222-4b77-b81c-ed75b119236c" />|


## Close 
close #433
