### PR TITLE
[#441] 초기화 시 dialog 가 늦게 사라지는 현상

### DIFF
--- a/presentation/mypage/src/main/kotlin/com/dhc/mypage/MyPageViewModel.kt
+++ b/presentation/mypage/src/main/kotlin/com/dhc/mypage/MyPageViewModel.kt
@@ -43,6 +43,7 @@ class MyPageViewModel @Inject constructor(
             is Event.ClickAppResetButton -> reduce { copy(isShowAppResetDialog = true) }
             is Event.ClickAppResetConfirmButton -> {
                 coroutineScope {
+                    reduce { copy(isShowAppResetDialog = false) }
                     authRepository.getUserId().firstOrNull()?.let {
                         dhcRepository.deleteUser(it)
                             .onSuccess {
@@ -56,7 +57,6 @@ class MyPageViewModel @Inject constructor(
                     } ?: run {
                         postSideEffect(SideEffect.ShowToast("회원 탈퇴에 실패했습니다"))
                     }
-                    reduce { copy(isShowAppResetDialog = false) }
                 }
             }
 


### PR DESCRIPTION
## 개요
🔑**이슈 링크** : https://github.com/mash-up-kr/DHC-Android/issues/441


## 💻작업 내용  
- 초기화 다이얼로그 일단 닫고 서버요청시키기


## 🗣️To Reviwers  
- 흠


## 👾시연 화면 (option)  

|Before|After|  
|---|---|
|<video src="https://github.com/user-attachments/assets/cbc945ae-5d7e-48c7-b6e0-9b7e2a39200f"/>|<video src="https://github.com/user-attachments/assets/63145129-bfc3-4a7a-b06d-2bf8eea475bd"/>|



## Close 
close #441 
