### PR TITLE
[#442] Intro Start 화면 VideoView 꽉채우기

### DIFF
--- a/presentation/intro/src/main/java/com/dhc/intro/start/IntroStartScreen.kt
+++ b/presentation/intro/src/main/java/com/dhc/intro/start/IntroStartScreen.kt
@@ -5,7 +5,6 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.aspectRatio
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -18,7 +17,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
-import androidx.compose.ui.graphics.graphicsLayer
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
@@ -44,10 +42,7 @@ fun IntroStartScreen(
         VideoView(
             videoResId = R.raw.intro_start_video,
             thumbnailResId = R.drawable.intro_start_video_thumbnail,
-            modifier = Modifier
-                .fillMaxWidth()
-                .align(Alignment.BottomCenter)
-                .aspectRatio(375f / 672f)
+            modifier = Modifier.fillMaxSize(),
         )
         Column(
             modifier = Modifier


### PR DESCRIPTION
## 개요
🔑**이슈 링크** : https://github.com/mash-up-kr/DHC-Android/issues/442


## 💻작업 내용  
- 비디오 풀스크린으로 채웠어용


## 🗣️To Reviwers  
- 찡끗

## 👾시연 화면 (option)  

|Before|After|  
|---|---|
|<video src="https://github.com/user-attachments/assets/80a797d2-77b0-47c3-b144-a0e3ecdc4d10"/>|<video src="https://github.com/user-attachments/assets/5bf4bde8-0f3c-4bd3-8082-5c3049dadf95"/>|



## Close 
close #442 
