### PR TITLE
[#463] 금전운 상세 그라디언트 수정

### DIFF
--- a/core/designsystem/src/main/kotlin/com/dhc/designsystem/score/DhcScoreText.kt
+++ b/core/designsystem/src/main/kotlin/com/dhc/designsystem/score/DhcScoreText.kt
@@ -6,19 +6,18 @@ import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Brush
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.dhc.designsystem.DhcTheme
 import com.dhc.designsystem.DhcTypoTokens
-import com.dhc.designsystem.GradientColor
 import com.dhc.designsystem.GradientColor.fortuneGradientLow
 import com.dhc.designsystem.GradientColor.fortuneGradientMid
 import com.dhc.designsystem.GradientColor.fortuneGradientTop
 import com.dhc.designsystem.LocalDhcColors
 import com.dhc.designsystem.R
-import com.dhc.designsystem.SurfaceColor
 import com.dhc.designsystem.badge.DhcBadge
 import com.dhc.designsystem.badge.model.BadgeType
 
@@ -28,14 +27,38 @@ fun DhcScoreText(
     score: Int,
     description: String,
     modifier: Modifier = Modifier,
+    isDefaultColor: Boolean = false
+) {
+    val textGradientColor =
+        if (isDefaultColor) fortuneGradientMid
+        else {
+            when (score) {
+                in 0 until 41 -> fortuneGradientLow
+                in 41 until 71 -> fortuneGradientMid
+                in 71..100 -> fortuneGradientTop
+                else -> fortuneGradientMid
+            }
+        }
+
+    DhcScoreText(
+        badgeText = badgeText,
+        score = stringResource(R.string.d_score, score),
+        description = description,
+        modifier = modifier,
+        textGradientColor = textGradientColor,
+    )
+}
+
+@Composable
+fun DhcScoreText(
+    badgeText: String?,
+    score: String,
+    description: String,
+    modifier: Modifier = Modifier,
+    textGradientColor: Brush = fortuneGradientMid,
 ) {
     val colors = LocalDhcColors.current
-    val textGradientColor = when (score) {
-        in 0 until 41 -> fortuneGradientLow
-        in 41 until 71 -> fortuneGradientMid
-        in 71..100 -> fortuneGradientTop
-        else -> fortuneGradientMid
-    }
+
     Column(
         verticalArrangement = Arrangement.spacedBy(12.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
@@ -48,7 +71,7 @@ fun DhcScoreText(
             )
         }
         Text(
-            text = stringResource(R.string.d_score, score),
+            text = score,
             style = DhcTypoTokens.TitleH0.copy(brush = textGradientColor),
         )
         Text(

--- a/core/designsystem/src/main/kotlin/com/dhc/designsystem/score/DhcScoreText.kt
+++ b/core/designsystem/src/main/kotlin/com/dhc/designsystem/score/DhcScoreText.kt
@@ -13,6 +13,9 @@ import androidx.compose.ui.unit.dp
 import com.dhc.designsystem.DhcTheme
 import com.dhc.designsystem.DhcTypoTokens
 import com.dhc.designsystem.GradientColor
+import com.dhc.designsystem.GradientColor.fortuneGradientLow
+import com.dhc.designsystem.GradientColor.fortuneGradientMid
+import com.dhc.designsystem.GradientColor.fortuneGradientTop
 import com.dhc.designsystem.LocalDhcColors
 import com.dhc.designsystem.R
 import com.dhc.designsystem.SurfaceColor
@@ -26,22 +29,13 @@ fun DhcScoreText(
     description: String,
     modifier: Modifier = Modifier,
 ) {
-    DhcScoreText(
-        badgeText = badgeText,
-        score = stringResource(R.string.d_score, score),
-        description = description,
-        modifier = modifier,
-    )
-}
-
-@Composable
-fun DhcScoreText(
-    badgeText: String?,
-    score: String,
-    description: String,
-    modifier: Modifier = Modifier,
-) {
     val colors = LocalDhcColors.current
+    val textGradientColor = when (score) {
+        in 0 until 41 -> fortuneGradientLow
+        in 41 until 71 -> fortuneGradientMid
+        in 71..100 -> fortuneGradientTop
+        else -> fortuneGradientMid
+    }
     Column(
         verticalArrangement = Arrangement.spacedBy(12.dp),
         horizontalAlignment = Alignment.CenterHorizontally,
@@ -54,8 +48,8 @@ fun DhcScoreText(
             )
         }
         Text(
-            text = score,
-            style = DhcTypoTokens.TitleH0.copy(brush = GradientColor.textGradient02),
+            text = stringResource(R.string.d_score, score),
+            style = DhcTypoTokens.TitleH0.copy(brush = textGradientColor),
         )
         Text(
             text = description,

--- a/presentation/home/src/main/java/com/dhc/home/main/HomeFlipCardScreen.kt
+++ b/presentation/home/src/main/java/com/dhc/home/main/HomeFlipCardScreen.kt
@@ -1,17 +1,12 @@
 package com.dhc.home.main
 
 import androidx.compose.foundation.Canvas
-import androidx.compose.foundation.background
-import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.Column
 import androidx.compose.foundation.layout.Spacer
-import androidx.compose.foundation.layout.WindowInsets
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.offset
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.size
-import androidx.compose.foundation.layout.statusBars
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.getValue
@@ -22,7 +17,6 @@ import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
@@ -37,7 +31,6 @@ import com.dhc.designsystem.fortunecard.FlippableBox
 import com.dhc.designsystem.score.DhcScoreText
 import com.dhc.home.R
 import com.dhc.home.model.TodayDailyFortuneUiModel
-import com.dhc.designsystem.R as DR
 import com.dhc.presentation.component.FortuneCardBack
 import com.dhc.presentation.component.WordBalloon
 import com.dhc.presentation.mvi.EventHandler
@@ -133,6 +126,7 @@ private fun FlippedDescription(
         },
         score = score,
         description = description,
+        isDefaultColor = true
     )
     Spacer(modifier = Modifier.height(64.dp))
 }

--- a/presentation/intro/src/main/java/com/dhc/intro/fortunecard/IntroFortuneCardScreen.kt
+++ b/presentation/intro/src/main/java/com/dhc/intro/fortunecard/IntroFortuneCardScreen.kt
@@ -145,6 +145,7 @@ private fun FlippedDescription() {
         badgeText = null,
         score = 85,
         description = stringResource(R.string.intro_flipped_fortune_card_description),
+        isDefaultColor = true
     )
     Spacer(modifier = Modifier.height(64.dp))
 }


### PR DESCRIPTION
## 개요
🔑**이슈 링크** : https://github.com/mash-up-kr/DHC-Android/issues/463


## 💻작업 내용  
 >작업한 내용을 구체적으로 작성해주세요.
- 금전운 상세 그라디언트를 빼먹어서 넣었어요

## 🗣️To Reviwers  
> 리뷰어들이 중점적으로 봤으면 하는 부분이나, 전달하고 싶은 사항에 대해 작성해주세요.
- 여기저기 얽혀있어서..살짝 애매하게 수정했는데ㅜㅜ방법이 떠오르지 않는다.
- 인트로는 85점이지만 영향없도록 구현~

## 👾시연 화면 (option)  

|기능A 구현|기능B 구현|  
|:---|---|
|<img width="268" height="591" alt="스크린샷 2025-07-17 오후 11 19 02" src="https://github.com/user-attachments/assets/d8d1d3ce-df83-49e9-b429-452b2d88d2ac" />|<img width="292" height="609" alt="스크린샷 2025-07-17 오후 11 19 54" src="https://github.com/user-attachments/assets/95848135-a5e0-4b30-9d95-186c6862c0d9" />|

## Close 
close #463
