### PR TITLE
[#276] SpendingHabitMissionCard onHeightChanged 함수 없이 개발가능하도록 리팩토링

### DIFF
--- a/core/designsystem/src/main/kotlin/com/dhc/designsystem/mission/MoneyFortuneMissionCard.kt
+++ b/core/designsystem/src/main/kotlin/com/dhc/designsystem/mission/MoneyFortuneMissionCard.kt
@@ -3,14 +3,12 @@ package com.dhc.designsystem.mission
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxWidth
-import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.width
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
 import androidx.compose.ui.tooling.preview.PreviewParameterProvider
@@ -33,7 +31,6 @@ fun MoneyFortuneMissionCard(
     isFinishedTodayMission: Boolean = false,
     onBlinkEnd: () -> Unit = {},
     onCheckChange: () -> Unit = {},
-    onHeightChanged: (Int) -> Unit = {},
 ) {
     val colors = LocalDhcColors.current
     val missionColor =
@@ -42,9 +39,7 @@ fun MoneyFortuneMissionCard(
         else SurfaceColor.neutral400
 
     MissionItemBackGround(
-        modifier = modifier.onSizeChanged {
-            onHeightChanged(it.height)
-        },
+        modifier = modifier,
         isBlink = isBlink,
         onBlinkEnd = onBlinkEnd,
         isChecked = isChecked,

--- a/core/designsystem/src/main/kotlin/com/dhc/designsystem/mission/SpendingHabitMissionCard.kt
+++ b/core/designsystem/src/main/kotlin/com/dhc/designsystem/mission/SpendingHabitMissionCard.kt
@@ -13,7 +13,6 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.ColorFilter
-import androidx.compose.ui.layout.onSizeChanged
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.tooling.preview.PreviewParameter
@@ -35,7 +34,6 @@ fun SpendingHabitMissionCard(
     isFinishedTodayMission: Boolean = false,
     isBlink: Boolean = false,
     onBlinkEnd: () -> Unit = {},
-    onHeightChanged: (Int) -> Unit = {},
     onCheckChange: () -> Unit = {}
 ) {
     val colors = LocalDhcColors.current
@@ -50,7 +48,6 @@ fun SpendingHabitMissionCard(
             .fillMaxWidth()
     ) {
         MissionItemBackGround(
-            modifier = Modifier.onSizeChanged{ onHeightChanged(it.height) },
             isChecked = isChecked,
             isEnabled = isFinishedTodayMission.not(),
             onCheckChange = onCheckChange,

--- a/core/designsystem/src/main/kotlin/com/dhc/designsystem/mission/SpendingHabitMissionCard.kt
+++ b/core/designsystem/src/main/kotlin/com/dhc/designsystem/mission/SpendingHabitMissionCard.kt
@@ -27,7 +27,6 @@ import com.dhc.designsystem.SurfaceColor
 import com.dhc.designsystem.badge.DhcBadge
 import com.dhc.designsystem.badge.model.BadgeType
 
-
 @Composable
 fun SpendingHabitMissionCard(
     missionDday: String,

--- a/data/src/debug/assets/mock_home_view_response.json
+++ b/data/src/debug/assets/mock_home_view_response.json
@@ -7,7 +7,7 @@
     "finished": false,
     "cost": "100",
     "endDate": "2025-12-31",
-    "title": "Run 10km every week",
+    "title": "Run 10km every week Run 10km every week Run 10km every week",
     "switchCount": 0
   },
   "todayDailyMissionList": [
@@ -41,7 +41,7 @@
       "finished": false,
       "cost": "30",
       "endDate": "2025-09-10",
-      "title": "Journal entry every day",
+      "title": "Journal entry every day Journal entry every day Journal entry every day",
       "switchCount": 0
     },
     {

--- a/presentation/home/src/main/java/com/dhc/home/main/HomeMissionComponent.kt
+++ b/presentation/home/src/main/java/com/dhc/home/main/HomeMissionComponent.kt
@@ -6,10 +6,6 @@ import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.getValue
-import androidx.compose.runtime.mutableIntStateOf
-import androidx.compose.runtime.remember
-import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
@@ -32,8 +28,6 @@ fun SpendingHabitMission(
     modifier: Modifier = Modifier,
     isFinishedTodayMission: Boolean = false,
 ) {
-    var missionChangeHeight by remember { mutableIntStateOf(0) }
-
     Column(
         modifier = modifier
     ) {
@@ -49,7 +43,6 @@ fun SpendingHabitMission(
         MissionCardReRoll(
             type = MissionType.LONG_TERM,
             modifier = Modifier.padding(top = 12.dp),
-            missionChangeHeight = missionChangeHeight,
             missionUiModel = missionUiModel,
             onClickMissionChange = { onClickMissionChange(missionUiModel) },
             onExpandedChange = { onExpandedChange(it, missionUiModel.missionId)},
@@ -60,7 +53,6 @@ fun SpendingHabitMission(
                     missionTitle = missionUiModel.title,
                     isChecked = missionUiModel.isChecked,
                     isFinishedTodayMission = isFinishedTodayMission,
-                    onHeightChanged = { missionChangeHeight = it },
                     onCheckChange = { onCheckChange( !missionUiModel.isChecked, missionUiModel.missionId)},
                     isBlink = missionUiModel.isBlink,
                     onBlinkEnd = { onBlinkEnd(missionUiModel.missionId) },
@@ -91,10 +83,8 @@ fun MonetaryLuckyDailyMission(
         Spacer(modifier = Modifier.height(16.dp))
         Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
             dailyMissionList.forEach { mission ->
-                var missionChangeHeight by remember { mutableIntStateOf(0) }
                 MissionCardReRoll(
                     type = MissionType.DAILY,
-                    missionChangeHeight = missionChangeHeight,
                     missionUiModel = mission,
                     onClickMissionChange = { onClickMissionChange(mission) },
                     onExpandedChange = { onExpandedChange(it, mission.missionId)},
@@ -107,7 +97,6 @@ fun MonetaryLuckyDailyMission(
                             isFinishedTodayMission = isFinishedTodayMission,
                             missionTitle = mission.title,
                             onBlinkEnd = { onBlinkEnd(mission.missionId) },
-                            onHeightChanged = { missionChangeHeight = it },
                             onCheckChange = { onCheckChange( !mission.isChecked, mission.missionId)}
                         )
                     }

--- a/presentation/home/src/main/java/com/dhc/home/main/MissionChange.kt
+++ b/presentation/home/src/main/java/com/dhc/home/main/MissionChange.kt
@@ -48,6 +48,7 @@ fun MissionCardReRoll(
     onClickMissionChange: () -> Unit,
     modifier: Modifier = Modifier,
     onExpandedChange: (Boolean) -> Unit,
+    subComposeMaximumRetry: Int = 2,
     content: @Composable () -> Unit,
 ) {
     var isExpanded by remember { mutableStateOf(missionUiModel.isExpanded) }
@@ -95,7 +96,8 @@ fun MissionCardReRoll(
                     content = content
                 )
             }.map { it.measure(constraints) }
-        } while (placeableList.maxOf { it.height } != contentMaxHeight)
+            // offset 등으로 실제 placeable height 과 content height 값이 다르면 다시 subCompose 시도
+        } while (placeableList.maxOf { it.height } != contentMaxHeight && number <= subComposeMaximumRetry)
 
         // 레이아웃 배치
         val placeableMaxSize = placeableList.fold(IntSize.Zero) { maxSize, placeable ->

--- a/presentation/home/src/main/java/com/dhc/home/main/MissionChange.kt
+++ b/presentation/home/src/main/java/com/dhc/home/main/MissionChange.kt
@@ -19,12 +19,16 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.graphicsLayer
+import androidx.compose.ui.layout.Placeable
+import androidx.compose.ui.layout.SubcomposeLayout
 import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.IntSize
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.util.fastMaxOfOrDefault
 import com.dhc.designsystem.AccentColor
 import com.dhc.designsystem.DhcTheme
 import com.dhc.designsystem.DhcTypoTokens
@@ -40,7 +44,6 @@ import com.dhc.designsystem.R as DR
 fun MissionCardReRoll(
     type: MissionType,
     canEnabled: Boolean,
-    missionChangeHeight: Int,
     missionUiModel: MissionUiModel,
     onClickMissionChange: () -> Unit,
     modifier: Modifier = Modifier,
@@ -56,26 +59,57 @@ fun MissionCardReRoll(
         isExpanded = missionUiModel.isExpanded
     }
 
-    DhcCardReRoll(
+    SubcomposeLayout(
         modifier = modifier
             .padding(horizontal = 16.dp)
-            .graphicsLayer { translationX = -(horizontalPadding.value * density.density) },
-        actionTopPadding = if(type == MissionType.LONG_TERM) 12.dp else 0.dp,
-        isExpanded = isExpanded,
-        onExpandedChange = {
-            isExpanded = it
-            onExpandedChange(it)
-        },
-        canEnabled = canEnabled,
-        actionContent = {
-            MissionChange(
-                modifier = Modifier
-                    .height(with(density) { missionChangeHeight.toDp() }),
-                onClickMissionChange = onClickMissionChange
+            .graphicsLayer { translationX = -(horizontalPadding.value * density.density) }
+    ) { constraints ->
+        // content composable 높이 확인
+        val contentPlaceableList = subcompose("content") { content() }.map { it.measure(constraints) }
+        val contentMaxHeight = contentPlaceableList.fold(0) { maxHeight, placeable ->
+            maxOf(maxHeight, placeable.height)
+        }
+
+        // content 높이와 actionContent 높이가 일치하는 placeableList 반환
+        var number = 0
+        var actionContentHeight = contentMaxHeight
+        var placeableList: List<Placeable> = emptyList()
+        do {
+            number++
+            actionContentHeight -= placeableList.fastMaxOfOrDefault(contentMaxHeight) { it.height } - contentMaxHeight
+            placeableList = subcompose("card$number") {
+                DhcCardReRoll(
+                    actionTopPadding = if(type == MissionType.LONG_TERM) 12.dp else 0.dp,
+                    isExpanded = isExpanded,
+                    onExpandedChange = {
+                        isExpanded = it
+                        onExpandedChange(it)
+                    },
+                    canEnabled = canEnabled,
+                    actionContent = {
+                        MissionChange(
+                            modifier = Modifier.height(with(density) { actionContentHeight.toDp() }),
+                            onClickMissionChange = onClickMissionChange
+                        )
+                    },
+                    content = content
+                )
+            }.map { it.measure(constraints) }
+        } while (placeableList.maxOf { it.height } != contentMaxHeight)
+
+        // 레이아웃 배치
+        val placeableMaxSize = placeableList.fold(IntSize.Zero) { maxSize, placeable ->
+            IntSize(
+                width = maxOf(maxSize.width, placeable.width),
+                height = maxOf(maxSize.height, placeable.height),
             )
-        },
-        content = content
-    )
+        }
+        layout(placeableMaxSize.width, placeableMaxSize.height) {
+            placeableList.forEach { placeable ->
+                placeable.placeRelative(0, 0)
+            }
+        }
+    }
 }
 
 
@@ -115,7 +149,6 @@ private fun PreviewMissionChange() {
     DhcTheme {
         MissionCardReRoll(
             type = MissionType.LONG_TERM,
-            missionChangeHeight = 0,
             canEnabled = true,
             onClickMissionChange = {},
             missionUiModel = MissionUiModel(),


### PR DESCRIPTION
## 개요
🔑**이슈 링크** : https://github.com/mash-up-kr/DHC-Android/issues/276


## 💻작업 내용  
- MissionCardReRoll 를 onHeightChanged 없이 SubcomposeLayout 으로 미리 높이값 계산해서 배치하는 형태로 리팩토링


## 🗣️To Reviwers  
- onHeightChanged 없이 구현이 가능했다.


## 👾시연 화면 (option)  

|시연|  
|---|
|<video src="https://github.com/user-attachments/assets/15e5d9af-705c-43ec-ab78-b13dc2a3f372"/>|

기존과 동일하게 동작한다.


## Close 
close #276 
