### PR TITLE
[#121] routeName 하드코딩하지 않도록 정적변수로 분리

### DIFF
--- a/app/src/main/java/com/dhc/dhcandroid/navigation/DhcApp.kt
+++ b/app/src/main/java/com/dhc/dhcandroid/navigation/DhcApp.kt
@@ -53,7 +53,7 @@ fun DhcApp(
             DhcBottomBar(
                 state = currentScreenConfig.bottomBarState,
                 currentRoute = DhcRoute.fromRoute(currentRoute).name,
-                navigateToRoute = { navController.navigateToBottomNavigation(DhcRoute.fromName(it)) },
+                navigateToRoute = { navController.navigateToBottomNavigation(DhcRoute.fromRoute(it)) },
                 modifier = Modifier
                     .fillMaxWidth()
                     .navigationBarsPadding(),

--- a/app/src/main/java/com/dhc/dhcandroid/navigation/DhcApp.kt
+++ b/app/src/main/java/com/dhc/dhcandroid/navigation/DhcApp.kt
@@ -52,7 +52,7 @@ fun DhcApp(
         bottomBar = {
             DhcBottomBar(
                 state = currentScreenConfig.bottomBarState,
-                currentRoute = DhcRoute.fromRoute(currentRoute).name,
+                currentRoute = DhcRoute.fromRoute(currentRoute).route,
                 navigateToRoute = { navController.navigateToBottomNavigation(DhcRoute.fromRoute(it)) },
                 modifier = Modifier
                     .fillMaxWidth()

--- a/app/src/main/java/com/dhc/dhcandroid/navigation/DhcRoute.kt
+++ b/app/src/main/java/com/dhc/dhcandroid/navigation/DhcRoute.kt
@@ -10,21 +10,21 @@ enum class DhcRoute(
     val screenConfig: ScreenConfig,
 ) {
     SPLASH(
-        route = "splash",
+        route = DhcRouteConst.SPLASH,
         screenConfig = ScreenConfig(
             topBarState = DhcTopBarState.None,
             bottomBarState = DhcBottomBarState.None,
         ),
     ),
     INTRO(
-        route = "intro",
+        route = DhcRouteConst.INTRO,
         screenConfig = ScreenConfig(
             topBarState = DhcTopBarState.None,
             bottomBarState = DhcBottomBarState.None,
         ),
     ),
     INTRO_START(
-        route = "intro/start",
+        route = DhcRouteConst.INTRO_START,
         screenConfig = ScreenConfig(
             topBarState = DhcTopBarState.None,
             bottomBarState = DhcBottomBarState.None,
@@ -32,21 +32,21 @@ enum class DhcRoute(
         ),
     ),
     INTRO_DESCRIPTION(
-        route = "intro/description",
+        route = DhcRouteConst.INTRO_DESCRIPTION,
         screenConfig = ScreenConfig(
             topBarState = DhcTopBarState.None,
             bottomBarState = DhcBottomBarState.None,
         ),
     ),
     INTRO_FORTUNE_CARD(
-        route = "intro/fortuneCard",
+        route = DhcRouteConst.INTRO_FORTUNE_CARD,
         screenConfig = ScreenConfig(
             topBarState = DhcTopBarState.None,
             bottomBarState = DhcBottomBarState.None,
         ),
     ),
     INTRO_FORTUNE_DETAIL(
-        route = "intro/fortuneDetail",
+        route = DhcRouteConst.INTRO_FORTUNE_DETAIL,
         screenConfig = ScreenConfig(
             topBarState = DhcTopBarState.None,
             bottomBarState = DhcBottomBarState.None,
@@ -54,14 +54,14 @@ enum class DhcRoute(
         ),
     ),
     INTRO_MISSION(
-        route = "intro/mission",
+        route = DhcRouteConst.INTRO_MISSION,
         screenConfig = ScreenConfig(
             topBarState = DhcTopBarState.None,
             bottomBarState = DhcBottomBarState.None,
         ),
     ),
     INTRO_GENDER(
-        route = "intro/gender",
+        route = DhcRouteConst.INTRO_GENDER,
         screenConfig = ScreenConfig(
             topBarState = DhcTopBarState.Basic(
                 title = "",
@@ -75,7 +75,7 @@ enum class DhcRoute(
         ),
     ),
     INTRO_BIRTH_DAY(
-        route = "intro/birthDay",
+        route = DhcRouteConst.INTRO_BIRTH_DAY,
         screenConfig = ScreenConfig(
             topBarState = DhcTopBarState.Basic(
                 title = "",
@@ -89,7 +89,7 @@ enum class DhcRoute(
         ),
     ),
     INTRO_BIRTH_TIME(
-        route = "intro/birthTime",
+        route = DhcRouteConst.INTRO_BIRTH_TIME,
         screenConfig = ScreenConfig(
             topBarState = DhcTopBarState.Basic(
                 title = "",
@@ -103,7 +103,7 @@ enum class DhcRoute(
         ),
     ),
     INTRO_CATEGORY(
-        route = "intro/category",
+        route = DhcRouteConst.INTRO_CATEGORY,
         screenConfig = ScreenConfig(
             topBarState = DhcTopBarState.Basic(
                 title = "",
@@ -117,27 +117,27 @@ enum class DhcRoute(
         ),
     ),
     MAIN_HOME(
-        route = "main/home",
+        route = DhcRouteConst.MAIN_HOME,
         screenConfig = ScreenConfig(
             bottomBarState = NavigationItemConst.mainGnbItemList,
             containerBackground = ContainerBackground.BackgroundWithTopRightGradientColor(),
         ),
     ),
     MAIN_MISSION(
-        route = "main/mission",
+        route = DhcRouteConst.MAIN_MISSION,
         screenConfig = ScreenConfig(
             bottomBarState = NavigationItemConst.mainGnbItemList,
             containerBackground = ContainerBackground.BackgroundWithTopRightGradientColor(),
         ),
     ),
     MAIN_MY(
-        route = "main/my",
+        route = DhcRouteConst.MAIN_MY,
         screenConfig = ScreenConfig(
             bottomBarState = NavigationItemConst.mainGnbItemList,
         ),
     ),
     HOME_MONETARY_DETAIL(
-        route = "home/monetaryDetail",
+        route = DhcRouteConst.HOME_MONETARY_DETAIL,
         screenConfig = ScreenConfig(
             topBarState = DhcTopBarState.Basic(
                 title = "오늘의 금전운",
@@ -147,7 +147,7 @@ enum class DhcRoute(
         ),
     ),
     NONE(
-        route = "none",
+        route = DhcRouteConst.NONE,
         screenConfig = ScreenConfig(),
     ), ;
 

--- a/app/src/main/java/com/dhc/dhcandroid/navigation/DhcRoute.kt
+++ b/app/src/main/java/com/dhc/dhcandroid/navigation/DhcRoute.kt
@@ -152,10 +152,6 @@ enum class DhcRoute(
     ), ;
 
     companion object {
-        fun fromName(name: String): DhcRoute {
-            return entries.find { it.name == name } ?: NONE
-        }
-
         fun fromRoute(route: String): DhcRoute {
             return entries.find { it.route.replace("{id}", "[^/]+").toRegex().matches(route) }
                 ?: NONE

--- a/app/src/main/java/com/dhc/dhcandroid/navigation/DhcRoute.kt
+++ b/app/src/main/java/com/dhc/dhcandroid/navigation/DhcRoute.kt
@@ -119,21 +119,21 @@ enum class DhcRoute(
     MAIN_HOME(
         route = "main/home",
         screenConfig = ScreenConfig(
-            bottomBarState = DhcBottomBarState.BottomNavigation,
+            bottomBarState = NavigationItemConst.mainGnbItemList,
             containerBackground = ContainerBackground.BackgroundWithTopRightGradientColor(),
         ),
     ),
     MAIN_MISSION(
         route = "main/mission",
         screenConfig = ScreenConfig(
-            bottomBarState = DhcBottomBarState.BottomNavigation,
+            bottomBarState = NavigationItemConst.mainGnbItemList,
             containerBackground = ContainerBackground.BackgroundWithTopRightGradientColor(),
         ),
     ),
     MAIN_MY(
         route = "main/my",
         screenConfig = ScreenConfig(
-            bottomBarState = DhcBottomBarState.BottomNavigation,
+            bottomBarState = NavigationItemConst.mainGnbItemList,
         ),
     ),
     HOME_MONETARY_DETAIL(

--- a/app/src/main/java/com/dhc/dhcandroid/navigation/DhcRouteConst.kt
+++ b/app/src/main/java/com/dhc/dhcandroid/navigation/DhcRouteConst.kt
@@ -1,0 +1,20 @@
+package com.dhc.dhcandroid.navigation
+
+object DhcRouteConst {
+    const val SPLASH = "splash"
+    const val INTRO = "intro"
+    const val INTRO_START = "intro/start"
+    const val INTRO_DESCRIPTION = "intro/description"
+    const val INTRO_FORTUNE_CARD = "intro/fortuneCard"
+    const val INTRO_FORTUNE_DETAIL = "intro/fortuneDetail"
+    const val INTRO_MISSION = "intro/mission"
+    const val INTRO_GENDER = "intro/gender"
+    const val INTRO_BIRTH_DAY = "intro/birthDay"
+    const val INTRO_BIRTH_TIME = "intro/birthTime"
+    const val INTRO_CATEGORY = "intro/category"
+    const val MAIN_HOME = "main/home"
+    const val MAIN_MISSION = "main/mission"
+    const val MAIN_MY = "main/my"
+    const val HOME_MONETARY_DETAIL = "home/monetaryDetail"
+    const val NONE = "none"
+}

--- a/app/src/main/java/com/dhc/dhcandroid/navigation/NavigationItemConst.kt
+++ b/app/src/main/java/com/dhc/dhcandroid/navigation/NavigationItemConst.kt
@@ -1,0 +1,27 @@
+package com.dhc.dhcandroid.navigation
+
+import com.dhc.designsystem.R
+import com.dhc.designsystem.gnb.model.DhcBottomBarState
+import com.dhc.designsystem.gnb.model.GnbItem
+
+object NavigationItemConst {
+    val mainGnbItemList = DhcBottomBarState.BottomNavigation(
+        listOf(
+            GnbItem(
+                iconResource = R.drawable.ico_home,
+                iconText = R.string.btn_bottom_home,
+                routeName = "main/home",
+            ),
+            GnbItem(
+                iconResource = R.drawable.ico_chart,
+                iconText = R.string.btn_bottom_mission,
+                routeName = "main/mission",
+            ),
+            GnbItem(
+                iconResource = R.drawable.ico_mypage,
+                iconText = R.string.btn_bottom_my_page,
+                routeName = "main/my",
+            ),
+        )
+    )
+}

--- a/app/src/main/java/com/dhc/dhcandroid/navigation/NavigationItemConst.kt
+++ b/app/src/main/java/com/dhc/dhcandroid/navigation/NavigationItemConst.kt
@@ -10,17 +10,17 @@ object NavigationItemConst {
             GnbItem(
                 iconResource = R.drawable.ico_home,
                 iconText = R.string.btn_bottom_home,
-                routeName = "main/home",
+                routeName = DhcRouteConst.MAIN_HOME,
             ),
             GnbItem(
                 iconResource = R.drawable.ico_chart,
                 iconText = R.string.btn_bottom_mission,
-                routeName = "main/mission",
+                routeName = DhcRouteConst.MAIN_MISSION,
             ),
             GnbItem(
                 iconResource = R.drawable.ico_mypage,
                 iconText = R.string.btn_bottom_my_page,
-                routeName = "main/my",
+                routeName = DhcRouteConst.MAIN_MY,
             ),
         )
     )

--- a/app/src/test/kotlin/com/dhc/dhcandroid/navigation/DhcRouteTest.kt
+++ b/app/src/test/kotlin/com/dhc/dhcandroid/navigation/DhcRouteTest.kt
@@ -18,20 +18,4 @@ class DhcRouteTest {
             assert(DhcRoute.fromRoute(route) == dhcRoute)
         }
     }
-
-    @Test
-    fun `fromName() Test`() {
-        val routeListTestCase: List<Pair<String, DhcRoute>> = listOf(
-            Pair("INTRO", DhcRoute.INTRO),
-            Pair("MAIN_HOME", DhcRoute.MAIN_HOME),
-            Pair("MAIN_MISSION", DhcRoute.MAIN_MISSION),
-            Pair("MAIN_MY", DhcRoute.MAIN_MY),
-            Pair("main", DhcRoute.NONE),
-            Pair("dhcdhcdhc/dhc", DhcRoute.NONE),
-        )
-
-        routeListTestCase.forEach { (route, dhcRoute) ->
-            assert(DhcRoute.fromName(route) == dhcRoute)
-        }
-    }
 }

--- a/core/designsystem/src/main/kotlin/com/dhc/designsystem/gnb/DhcBottomBar.kt
+++ b/core/designsystem/src/main/kotlin/com/dhc/designsystem/gnb/DhcBottomBar.kt
@@ -17,11 +17,6 @@ fun DhcBottomBar(
     navigateToRoute: (String) -> Unit,
     modifier: Modifier = Modifier,
 ) {
-    val items = DhcBottomBarState.BottomNavigation.items
-    val selectedIndex = items
-        .indexOfFirst { it.routeName == currentRoute }
-        .coerceAtLeast(0)
-
     AnimatedContent(
         targetState = state,
         transitionSpec = {
@@ -37,8 +32,10 @@ fun DhcBottomBar(
         when (currentState) {
             is DhcBottomBarState.BottomNavigation -> {
                 DhcGnb(
-                    gnbItemList = items,
-                    selectedIndex = selectedIndex,
+                    gnbItemList = currentState.items,
+                    selectedIndex = currentState.items
+                        .indexOfFirst { it.routeName == currentRoute }
+                        .coerceAtLeast(0),
                     onClickItem = { gnbItem, _ ->
                         navigateToRoute(gnbItem.routeName)
                     },

--- a/core/designsystem/src/main/kotlin/com/dhc/designsystem/gnb/DhcBottomBar.kt
+++ b/core/designsystem/src/main/kotlin/com/dhc/designsystem/gnb/DhcBottomBar.kt
@@ -6,6 +6,7 @@ import androidx.compose.animation.slideOutVertically
 import androidx.compose.animation.togetherWith
 import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.dhc.designsystem.gnb.model.DhcBottomBarState

--- a/core/designsystem/src/main/kotlin/com/dhc/designsystem/gnb/DhcGnb.kt
+++ b/core/designsystem/src/main/kotlin/com/dhc/designsystem/gnb/DhcGnb.kt
@@ -73,17 +73,17 @@ private fun DhcGnbPreview() {
                 GnbItem(
                     iconResource = R.drawable.ico_home,
                     iconText = R.string.btn_bottom_home,
-                    routeName = "MAIN_HOME",
+                    routeName = "main/home",
                 ),
                 GnbItem(
                     iconResource = R.drawable.ico_chart,
                     iconText = R.string.btn_bottom_mission,
-                    routeName = "MAIN_MISSION",
+                    routeName = "main/mission",
                 ),
                 GnbItem(
                     iconResource = R.drawable.ico_mypage,
                     iconText = R.string.btn_bottom_my_page,
-                    routeName = "MAIN_MY",
+                    routeName = "main/my",
                 ),
             ),
             selectedIndex = 0,

--- a/core/designsystem/src/main/kotlin/com/dhc/designsystem/gnb/model/DhcBottomBarState.kt
+++ b/core/designsystem/src/main/kotlin/com/dhc/designsystem/gnb/model/DhcBottomBarState.kt
@@ -6,4 +6,5 @@ sealed interface DhcBottomBarState {
 
     data class BottomNavigation(
         val items: List<GnbItem>,
-    ) : DhcBottomBarState}
+    ) : DhcBottomBarState
+}

--- a/core/designsystem/src/main/kotlin/com/dhc/designsystem/gnb/model/DhcBottomBarState.kt
+++ b/core/designsystem/src/main/kotlin/com/dhc/designsystem/gnb/model/DhcBottomBarState.kt
@@ -1,28 +1,9 @@
 package com.dhc.designsystem.gnb.model
 
-import com.dhc.designsystem.R
-
 sealed interface DhcBottomBarState {
 
     data object None : DhcBottomBarState
 
-    data object BottomNavigation : DhcBottomBarState {
-        val items = listOf(
-            GnbItem(
-                iconResource = R.drawable.ico_home,
-                iconText = R.string.btn_bottom_home,
-                routeName = "MAIN_HOME",
-            ),
-            GnbItem(
-                iconResource = R.drawable.ico_chart,
-                iconText = R.string.btn_bottom_mission,
-                routeName = "MAIN_MISSION",
-            ),
-            GnbItem(
-                iconResource = R.drawable.ico_mypage,
-                iconText = R.string.btn_bottom_my_page,
-                routeName = "MAIN_MY",
-            ),
-        )
-    }
-}
+    data class BottomNavigation(
+        val items: List<GnbItem>,
+    ) : DhcBottomBarState}


### PR DESCRIPTION
## 개요
🔑**이슈 링크** : https://github.com/mash-up-kr/DHC-Android/issues/121


## 💻작업 내용  
- route 정보를 DhcRouteConst 로 분리
- Main BottomBar 를 DhcBottomBarState 로 분리하여 재사용 가능하게 구조 변경했습니다


## 🗣️To Reviwers  
- 심심해서 해봤습니다.
- routeName 은 이제 DhcRouteConst 에서 관리합니다. 그리고 되도록 DhcRoute.xxx 를 통해 route 정보를 사용할 예정입니다.


## 👾시연 화면 (option)  
화면간 네비게이션 시 정상동작 확인

## Close 
close #121 
