### PR TITLE
[#490] 카테고리 선택화면 에러페이지 추가

### DIFF
--- a/presentation/intro/src/main/java/com/dhc/intro/category/IntroCategoryContract.kt
+++ b/presentation/intro/src/main/java/com/dhc/intro/category/IntroCategoryContract.kt
@@ -10,14 +10,22 @@ class IntroCategoryContract {
     data class State(
         val categoryItems: List<CategoryItem> = emptyList(),
         val selectedIndexSet: Set<Int> = emptySet(),
+        val loadState: LoadState = LoadState.Loading,
     ) : UiState {
         val selectedCategoryItems get() = categoryItems.filterIndexed { index, _ -> selectedIndexSet.contains(index) }
         val nextButtonEnabled: Boolean = selectedIndexSet.size > 2
     }
 
+    enum class LoadState {
+        Loading,
+        Success,
+        Error,
+    }
+
     sealed interface Event : UiEvent {
         data class ClickNextButton(val currentState: State) : Event
         data class ClickCategoryItem(val selectedIndex: Int) : Event
+        data object ClickRetryButton : Event
     }
 
     sealed interface SideEffect : UiSideEffect {

--- a/presentation/intro/src/main/java/com/dhc/intro/category/IntroCategoryRoute.kt
+++ b/presentation/intro/src/main/java/com/dhc/intro/category/IntroCategoryRoute.kt
@@ -1,12 +1,16 @@
 package com.dhc.intro.category
 
+import androidx.compose.foundation.layout.Box
 import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.material3.CircularProgressIndicator
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
 import androidx.hilt.navigation.compose.hiltViewModel
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.dhc.presentation.ui.ErrorScreen
 
 @Composable
 fun IntroCategoryRoute(
@@ -23,9 +27,26 @@ fun IntroCategoryRoute(
         }
     }
 
-    IntroCategoryScreen(
-        state = state,
-        eventHandler = viewModel::sendEvent,
-        modifier = Modifier.fillMaxSize(),
-    )
+    when (state.loadState) {
+        IntroCategoryContract.LoadState.Loading -> {
+            Box(modifier = Modifier.fillMaxSize()) {
+                CircularProgressIndicator(modifier = Modifier.align(Alignment.Center))
+            }
+        }
+
+        IntroCategoryContract.LoadState.Error -> {
+            ErrorScreen(
+                onClickRetry = { viewModel.sendEvent(IntroCategoryContract.Event.ClickRetryButton) },
+                modifier = Modifier.fillMaxSize(),
+            )
+        }
+
+        IntroCategoryContract.LoadState.Success -> {
+            IntroCategoryScreen(
+                state = state,
+                eventHandler = viewModel::sendEvent,
+                modifier = Modifier.fillMaxSize(),
+            )
+        }
+    }
 }

--- a/presentation/intro/src/main/java/com/dhc/intro/category/IntroCategoryViewModel.kt
+++ b/presentation/intro/src/main/java/com/dhc/intro/category/IntroCategoryViewModel.kt
@@ -26,15 +26,32 @@ class IntroCategoryViewModel @Inject constructor(
 
     init {
         viewModelScope.launch {
-            val categoryItems = dhcRepository.getMissionCategories().getSuccessOrNull()?.categories?.map {
-                CategoryItem(
-                    name = it.name,
-                    displayName = it.displayName,
-                    imageUrl = it.image
-                )
-            } ?: emptyList()
+            loadData()
+        }
+    }
 
-            reduce { copy(categoryItems = categoryItems) }
+    private suspend fun loadData() {
+        val categoryItems = dhcRepository.getMissionCategories().getSuccessOrNull()?.categories?.map {
+            CategoryItem(
+                name = it.name,
+                displayName = it.displayName,
+                imageUrl = it.image
+            )
+        }
+
+        if (categoryItems == null) {
+            reduce {
+                copy(
+                    loadState = IntroCategoryContract.LoadState.Error,
+                )
+            }
+        } else {
+            reduce {
+                copy(
+                    categoryItems = categoryItems,
+                    loadState = IntroCategoryContract.LoadState.Success,
+                )
+            }
         }
     }
 
@@ -65,6 +82,14 @@ class IntroCategoryViewModel @Inject constructor(
                         selectedIndexSet + event.selectedIndex
                     }
                 )
+            }
+            is Event.ClickRetryButton -> {
+                reduce {
+                    copy(
+                        loadState = IntroCategoryContract.LoadState.Loading,
+                    )
+                }
+                loadData()
             }
         }
     }


### PR DESCRIPTION
## 개요
🔑**이슈 링크** : https://github.com/mash-up-kr/DHC-Android/issues/490


## 💻작업 내용  
 - 사용성을 위해 카테고리 선택화면에 로딩페이지와 에러페이지를 추가합니다.


## 🗣️To Reviwers  
-

## 👾시연 화면 (option)  

|로딩 및 에러|성공|  
|---|---|
|<video src="https://github.com/user-attachments/assets/6c5c5216-6592-41cf-8b47-fd52b067e189"/>|<video src="https://github.com/user-attachments/assets/eb5592df-8421-43fa-ac13-387e3f788d71"/>|

## Close 
close #490 
