### PR TITLE
[#496] 미션변경시 배경 글씨가 디자인가이드에 안맞는 이슈

### DIFF
--- a/presentation/home/src/main/java/com/dhc/home/main/MissionChange.kt
+++ b/presentation/home/src/main/java/com/dhc/home/main/MissionChange.kt
@@ -132,14 +132,14 @@ fun MissionChange(
     ) {
         Icon(
             painter = painterResource(DR.drawable.ico_change),
-            tint = SurfaceColor.neutral30,
+            tint = colors.background.backgroundMain,
             contentDescription = "change",
         )
         Spacer(modifier = Modifier.height(4.dp))
         Text(
             text = stringResource(R.string.change_mission),
             style = DhcTypoTokens.Body5,
-            color = colors.text.textMain,
+            color = colors.background.backgroundMain,
             textAlign = TextAlign.Center,
         )
     }


### PR DESCRIPTION
## 개요
🔑**이슈 링크** : https://github.com/mash-up-kr/DHC-Android/issues/496


## 💻작업 내용  
- 색상 바꿨어용


## 🗣️To Reviwers  



## 👾시연 화면 (option)  

|기능 구현|  
|---|
|<img width="566" height="1261" alt="스크린샷 2026-02-02 오후 11 23 22" src="https://github.com/user-attachments/assets/179a7fe5-6a70-4256-b5c9-1b0bbb6bf580" />|


## Close 
close #496
