### PR TITLE
[#499] bottomBar 사라질때 애니메이션 오른쪽 밑으로 가는 이상현상 해결

### DIFF
--- a/core/designsystem/src/main/kotlin/com/dhc/designsystem/gnb/DhcBottomBar.kt
+++ b/core/designsystem/src/main/kotlin/com/dhc/designsystem/gnb/DhcBottomBar.kt
@@ -4,9 +4,10 @@ import androidx.compose.animation.AnimatedContent
 import androidx.compose.animation.slideInVertically
 import androidx.compose.animation.slideOutVertically
 import androidx.compose.animation.togetherWith
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.runtime.Composable
-import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.unit.dp
 import com.dhc.designsystem.gnb.model.DhcBottomBarState
@@ -44,7 +45,9 @@ fun DhcBottomBar(
                 )
             }
 
-            is DhcBottomBarState.None -> Unit
+            is DhcBottomBarState.None -> {
+                Spacer(modifier = Modifier.fillMaxWidth())
+            }
         }
     }
 }


### PR DESCRIPTION
## 개요
🔑**이슈 링크** : https://github.com/mash-up-kr/DHC-Android/issues/499 


## 💻작업 내용  
- 바텀내비게이션 사라질때 오른쪽 밑으로 사라지는 애니메이션 이상현상 제거함


## 🗣️To Reviwers  
-

## 👾시연 화면 (option)  

|기능A 구현|
|:---|
|<video src="https://github.com/user-attachments/assets/f46efb85-51ec-45e7-a816-3fa1c602178d"/>|

## Close 
close #499 
