### PR TITLE
[#505] 뒤로가기 가로채서 웹뷰에 적용하기

### DIFF
--- a/presentation/survey/src/main/java/com/example/survey/SurveyScreen.kt
+++ b/presentation/survey/src/main/java/com/example/survey/SurveyScreen.kt
@@ -4,8 +4,13 @@ import android.annotation.SuppressLint
 import android.view.ViewGroup
 import android.webkit.CookieManager
 import android.webkit.WebView
+import androidx.activity.compose.BackHandler
 import androidx.activity.compose.LocalActivity
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.toArgb
 import androidx.compose.ui.viewinterop.AndroidView
@@ -23,6 +28,14 @@ fun SurveyScreen(
 ) {
     val activity = LocalActivity.current
     val colors = LocalDhcColors.current
+
+    var canGoBack: Boolean by remember { mutableStateOf(false) }
+    var webView: WebView? by remember { mutableStateOf(null) }
+
+    BackHandler(enabled = canGoBack) {
+        webView?.goBack()
+    }
+
     AndroidView(
         factory = { context ->
             state.shareToken?.let {
@@ -52,7 +65,14 @@ fun SurveyScreen(
                     ),
                     "DHCJavascriptInterface",
                 )
+                webViewClient = SurveyWebViewClient(
+                    canGoBackChanged = { updatedCanGoBack ->
+                        canGoBack = updatedCanGoBack
+                    },
+                )
                 loadUrl(DhcWebUrl)
+            }.also {
+                webView = it
             }
         },
         modifier = modifier,

--- a/presentation/survey/src/main/java/com/example/survey/SurveyWebViewClient.kt
+++ b/presentation/survey/src/main/java/com/example/survey/SurveyWebViewClient.kt
@@ -1,0 +1,13 @@
+package com.example.survey
+
+import android.webkit.WebView
+import android.webkit.WebViewClient
+
+class SurveyWebViewClient(
+    val canGoBackChanged: (Boolean) -> Unit,
+) : WebViewClient() {
+    override fun doUpdateVisitedHistory(view: WebView?, url: String?, isReload: Boolean) {
+        super.doUpdateVisitedHistory(view, url, isReload)
+        view?.canGoBack()?.let { canGoBackChanged(it) }
+    }
+}


### PR DESCRIPTION
## 개요
🔑**이슈 링크** : https://github.com/mash-up-kr/DHC-Android/issues/505 


## 💻작업 내용  
- WebView 에서 기기 뒤로가기하면 웹뷰가 닫히는 이슈가 있어서 수정 했습니다.

## 🗣️To Reviwers  
- 


## 👾시연 화면 (option)  

|기능 구현|  
|---|
|<video src="https://github.com/user-attachments/assets/40679d27-e67d-4203-b6d5-718d6e2f3846"/>|


## Close 
close #505 
