### PR TITLE
aab 생성하는 github action 불필요한 task 최소화

### DIFF
--- a/.github/workflows/generate-aab.yaml
+++ b/.github/workflows/generate-aab.yaml
@@ -34,7 +34,7 @@ jobs:
         run: chmod +x gradlew
 
       - name: Build Release AAB
-        run: ./gradlew bundleRelease
+        run: ./gradlew bundleRealRelease
 
       - name: Sign AAB
         id: sign_app


### PR DESCRIPTION
## 개요
🔑**이슈 링크** :  -


## 💻작업 내용  
- aab 생성하는 github action 불필요한 task 최소화


## 🗣️To Reviwers  
- bundleRelease 를 하면 모든 flavor 에 대해서 실행됩니다. 
- 그래서 bundleDevRelease, bundleMockRelease, bundleRealRelease 모두 실행되는 대참사가 일어나고, 시간이 3배나 오래걸리게 됩니다.
- 이를 수정합니다.