### PR TITLE
[#519] API Field Naming 통일 작업

### DIFF
--- a/data/src/main/kotlin/com/dhc/dhcandroid/model/MyPageResponse.kt
+++ b/data/src/main/kotlin/com/dhc/dhcandroid/model/MyPageResponse.kt
@@ -9,10 +9,18 @@ data class MyPageResponse(
     val birthTime: String? = null,
     val preferredMissionCategoryList: List<MissionCategoryResponse> = emptyList(),
     val alarm: Boolean = false,
+    val fortuneTests: List<FortuneTestInfo> = emptyList(),
 )
 
 @Serializable
 data class AnimalCard(
     val name: String = "",
     val cardImage: String? = null
+)
+
+@Serializable
+data class FortuneTestInfo(
+    val image: String = "",
+    val displayName: String = "",
+    val testUrl: String = "",
 )

--- a/data/src/main/kotlin/com/dhc/dhcandroid/model/RewardProgressResponse.kt
+++ b/data/src/main/kotlin/com/dhc/dhcandroid/model/RewardProgressResponse.kt
@@ -10,7 +10,7 @@ data class RewardProgressResponse(
 
 @Serializable
 data class RewardUser(
-    val rewardImageUrl: String = "",
+    val image: String = "",
     val rewardLevel: RewardLevel = RewardLevel(),
     val totalPoint: Int = 0,
     val currentLevelPoint: Int = 0,
@@ -30,5 +30,6 @@ data class RewardItem(
     val title: String = "",
     val isUnlocked: Boolean = false,
     val isUsed: Boolean = false,
+    val icon: String = "",
     val message: String = "",
 )

--- a/data/src/main/kotlin/com/dhc/dhcandroid/model/TestBannerResponse.kt
+++ b/data/src/main/kotlin/com/dhc/dhcandroid/model/TestBannerResponse.kt
@@ -7,6 +7,6 @@ data class TestBannerResponse(
     val version: Int = 0,
     val title: String = "",
     val subTitle: String = "",
-    val imageUrl: String = "",
+    val image: String = "",
     val testUrl: String = "",
 )

--- a/presentation/home/src/main/java/com/dhc/home/model/TestBannerUiModel.kt
+++ b/presentation/home/src/main/java/com/dhc/home/model/TestBannerUiModel.kt
@@ -12,7 +12,7 @@ data class TestBannerUiModel(
         fun from(model: TestBannerResponse): TestBannerUiModel = TestBannerUiModel(
             title = model.title,
             subTitle = model.subTitle,
-            imageUrl = model.imageUrl,
+            imageUrl = model.image,
             testUrl = model.testUrl,
         )
     }

--- a/presentation/mypage/src/main/kotlin/com/dhc/mypage/model/MyInfoUiModel.kt
+++ b/presentation/mypage/src/main/kotlin/com/dhc/mypage/model/MyInfoUiModel.kt
@@ -1,5 +1,6 @@
 package com.dhc.mypage.model
 
+import com.dhc.dhcandroid.model.FortuneTestInfo
 import com.dhc.dhcandroid.model.MyPageResponse
 import java.time.LocalDate
 import java.time.LocalTime
@@ -9,6 +10,7 @@ data class MyInfoUiModel(
     val animalImageUrl: String? = null,
     val birthDate: LocalDate? = null,
     val birthTime: LocalTime? = null,
+    val fortuneTestInfoList: List<FortuneTestInfo> = emptyList(),
 ) {
     companion object {
         fun from(myPageResponse: MyPageResponse) = MyInfoUiModel(
@@ -16,6 +18,7 @@ data class MyInfoUiModel(
             animalImageUrl = myPageResponse.animalCard.cardImage,
             birthDate = myPageResponse.birthDate?.let { runCatching { LocalDate.parse(it.date) }.getOrNull() },
             birthTime = myPageResponse.birthTime?.let { runCatching { LocalTime.parse(it) }.getOrNull() },
+            fortuneTestInfoList = myPageResponse.fortuneTests
         )
     }
 }

--- a/presentation/mypage/src/main/kotlin/com/dhc/mypage/ui/MyPageScreen.kt
+++ b/presentation/mypage/src/main/kotlin/com/dhc/mypage/ui/MyPageScreen.kt
@@ -3,6 +3,7 @@ package com.dhc.mypage.ui
 import android.content.ClipData
 import android.content.ClipboardManager
 import android.content.Context
+import android.util.Log
 import androidx.activity.compose.LocalActivity
 import androidx.compose.foundation.Canvas
 import androidx.compose.foundation.Image
@@ -37,6 +38,7 @@ import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
 import com.dhc.common.DHC_WEB_URL_LOVE_TEST
+import com.dhc.common.ImageResource
 import com.dhc.designsystem.DhcTheme
 import com.dhc.designsystem.DhcTypoTokens
 import com.dhc.designsystem.GradientColor.backgroundGradient01
@@ -194,19 +196,21 @@ private fun Setting(
             style = DhcTypoTokens.Body3,
             color = SurfaceColor.neutral30,
         )
-        SettingList(
-            modifier = Modifier
-                .fillMaxWidth()
-                .padding(horizontal = 20.dp),
-            settingItems = listOf(
-                SettingItem.Normal(
-                    text = stringResource(R.string.check_fortune_test),
-                    iconRes = DR.drawable.ico_couple,
-                    onClick = { eventHandler(Event.ClickFortuneSurveyButton(DHC_WEB_URL_LOVE_TEST)) },
-                    isArrowVisible = true,
-                ),
+        state.myInfo.fortuneTestInfoList.forEach { fortuneTestInfo ->
+            SettingList(
+                modifier = Modifier
+                    .fillMaxWidth()
+                    .padding(horizontal = 20.dp),
+                settingItems = listOf(
+                    SettingItem.Normal(
+                        text = stringResource(R.string.check_fortune_test),
+                        imageResource = ImageResource.Url(fortuneTestInfo.image),
+                        onClick = { eventHandler(Event.ClickFortuneSurveyButton(fortuneTestInfo.testUrl)) },
+                        isArrowVisible = true,
+                    ),
+                )
             )
-        )
+        }
 
         Text(
             modifier = Modifier.padding(start = 20.dp, top = 24.dp, bottom = 12.dp, end = 20.dp),
@@ -221,7 +225,7 @@ private fun Setting(
             settingItems = listOf(
                 SettingItem.Normal(
                     text = stringResource(R.string.initial_app),
-                    iconRes = DR.drawable.ico_sign_out,
+                    imageResource = ImageResource.Drawable(DR.drawable.ico_sign_out),
                     onClick = { eventHandler(Event.ClickAppResetButton) },
                     isArrowVisible = false,
                 ),

--- a/presentation/mypage/src/main/kotlin/com/dhc/mypage/ui/settinglist/SettingItem.kt
+++ b/presentation/mypage/src/main/kotlin/com/dhc/mypage/ui/settinglist/SettingItem.kt
@@ -1,22 +1,21 @@
 package com.dhc.mypage.ui.settinglist
 
-import androidx.annotation.DrawableRes
+import com.dhc.common.ImageResource
 
 internal sealed interface SettingItem {
     val text: String
-    @get:DrawableRes
-    val iconRes: Int
+    val imageResource: ImageResource
 
     data class Normal(
         override val text: String,
-        @DrawableRes override val iconRes: Int,
+        override val imageResource: ImageResource,
         val isArrowVisible: Boolean,
         val onClick: () -> Unit = {},
     ): SettingItem
 
     data class Toggle(
         override val text: String,
-        @DrawableRes override val iconRes: Int,
+        override val imageResource: ImageResource,
         val isOn: Boolean,
         val onCheckedChange: (Boolean) -> Unit = {},
     ): SettingItem

--- a/presentation/mypage/src/main/kotlin/com/dhc/mypage/ui/settinglist/SettingList.kt
+++ b/presentation/mypage/src/main/kotlin/com/dhc/mypage/ui/settinglist/SettingList.kt
@@ -11,6 +11,7 @@ import androidx.compose.runtime.Composable
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import com.dhc.common.ImageResource
 import com.dhc.designsystem.DhcTheme
 import com.dhc.designsystem.LocalDhcColors
 import com.dhc.designsystem.SurfaceColor
@@ -63,11 +64,11 @@ private fun SettingListPreview() {
     DhcTheme {
         SettingList(
             settingItems = listOf(
-                SettingItem.Normal(text = "내 정보", iconRes = DR.drawable.ico_sign_out, isArrowVisible = false),
-                SettingItem.Toggle(text = "알림 설정", iconRes = DR.drawable.ico_sign_out, isOn = true),
-                SettingItem.Normal(text = "고객센터", iconRes = DR.drawable.ico_sign_out, isArrowVisible = false),
-                SettingItem.Normal(text = "약관 및 정책", iconRes = DR.drawable.ico_sign_out, isArrowVisible = true),
-                SettingItem.Normal(text = "로그아웃", iconRes = DR.drawable.ico_sign_out, isArrowVisible = false),
+                SettingItem.Normal(text = "내 정보", imageResource = ImageResource.Drawable(DR.drawable.ico_sign_out), isArrowVisible = false),
+                SettingItem.Toggle(text = "알림 설정", imageResource = ImageResource.Drawable(DR.drawable.ico_sign_out), isOn = true),
+                SettingItem.Normal(text = "고객센터", imageResource = ImageResource.Drawable(DR.drawable.ico_sign_out), isArrowVisible = false),
+                SettingItem.Normal(text = "약관 및 정책", imageResource = ImageResource.Drawable(DR.drawable.ico_sign_out), isArrowVisible = true),
+                SettingItem.Normal(text = "로그아웃", imageResource = ImageResource.Drawable(DR.drawable.ico_sign_out), isArrowVisible = false),
             )
         )
     }

--- a/presentation/mypage/src/main/kotlin/com/dhc/mypage/ui/settinglist/SettingNormalItem.kt
+++ b/presentation/mypage/src/main/kotlin/com/dhc/mypage/ui/settinglist/SettingNormalItem.kt
@@ -5,6 +5,7 @@ import androidx.compose.foundation.clickable
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
 import androidx.compose.material3.Text
 import androidx.compose.runtime.Composable
 import androidx.compose.ui.Alignment
@@ -12,6 +13,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import coil3.compose.AsyncImage
+import com.dhc.common.ImageResource
 import com.dhc.designsystem.DhcTheme
 import com.dhc.designsystem.DhcTypoTokens
 import com.dhc.designsystem.LocalDhcColors
@@ -29,10 +32,21 @@ internal fun SettingNormalItem(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(8.dp),
     ) {
-        Image(
-            painter = painterResource(item.iconRes),
-            contentDescription = "sign out",
-        )
+        when (item.imageResource) {
+            is ImageResource.Drawable -> {
+                Image(
+                    painter = painterResource(item.imageResource.resId),
+                    contentDescription = "",
+                )
+            }
+            is ImageResource.Url -> {
+                AsyncImage(
+                    model = item.imageResource.url,
+                    contentDescription = "",
+                    modifier = Modifier.size(20.dp),
+                )
+            }
+        }
         Text(
             modifier = Modifier.weight(1f),
             text = item.text,
@@ -49,7 +63,7 @@ private fun SettingNormalItemPreview() {
         SettingNormalItem(
             item = SettingItem.Normal(
                 text = "로그아웃",
-                iconRes = DR.drawable.ico_sign_out,
+                imageResource = ImageResource.Drawable(DR.drawable.ico_sign_out),
                 isArrowVisible = false,
             ),
             modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),

--- a/presentation/mypage/src/main/kotlin/com/dhc/mypage/ui/settinglist/SettingToggleItem.kt
+++ b/presentation/mypage/src/main/kotlin/com/dhc/mypage/ui/settinglist/SettingToggleItem.kt
@@ -1,5 +1,6 @@
 package com.dhc.mypage.ui.settinglist
 
+import android.R.attr.text
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Row
@@ -12,6 +13,8 @@ import androidx.compose.ui.Modifier
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
+import coil3.compose.AsyncImage
+import com.dhc.common.ImageResource
 import com.dhc.designsystem.DhcTheme
 import com.dhc.designsystem.DhcTypoTokens
 import com.dhc.designsystem.LocalDhcColors
@@ -30,11 +33,21 @@ internal fun SettingToggleItem(
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(8.dp),
     ) {
-        Image(
-            painter = painterResource(item.iconRes),
-            contentDescription = "sign out",
-            modifier = Modifier.size(20.dp),
-        )
+        when (item.imageResource) {
+            is ImageResource.Drawable -> {
+                Image(
+                    painter = painterResource(item.imageResource.resId),
+                    contentDescription = "",
+                )
+            }
+            is ImageResource.Url -> {
+                AsyncImage(
+                    model = item.imageResource.url,
+                    contentDescription = "",
+                    modifier = Modifier.size(20.dp),
+                )
+            }
+        }
         Text(
             modifier = Modifier.weight(1f),
             text = item.text,
@@ -55,9 +68,9 @@ private fun SettingToggleItemPreview() {
         SettingToggleItem(
             item = SettingItem.Toggle(
                 text = "알림 설정",
-                iconRes = DR.drawable.ico_sign_out,
+                imageResource = ImageResource.Drawable(DR.drawable.ico_sign_out),
                 isOn = true,
-                onCheckedChange = {}
+                onCheckedChange = {},
             ),
             modifier = Modifier.padding(horizontal = 16.dp, vertical = 8.dp),
         )

--- a/presentation/reward/src/main/java/com/dhc/reward/RewardScreen.kt
+++ b/presentation/reward/src/main/java/com/dhc/reward/RewardScreen.kt
@@ -24,26 +24,19 @@ import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.ExperimentalMaterial3Api
 import androidx.compose.material3.Text
 import androidx.compose.material3.TooltipBox
-import androidx.compose.material3.TooltipDefaults
 import androidx.compose.material3.rememberTooltipState
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.rememberCoroutineScope
 import androidx.compose.ui.Alignment
-import androidx.compose.ui.platform.LocalConfiguration
-import androidx.compose.ui.platform.LocalDensity
-import androidx.compose.ui.unit.IntOffset
-import androidx.compose.ui.unit.IntRect
-import androidx.compose.ui.unit.IntSize
-import androidx.compose.ui.unit.LayoutDirection
-import androidx.compose.ui.window.PopupPositionProvider
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.draw.clip
 import androidx.compose.ui.draw.drawBehind
 import androidx.compose.ui.graphics.Brush
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.graphics.Path
+import androidx.compose.ui.platform.LocalConfiguration
+import androidx.compose.ui.platform.LocalDensity
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.text.SpanStyle
@@ -52,13 +45,17 @@ import androidx.compose.ui.text.style.TextAlign
 import androidx.compose.ui.text.style.TextDecoration
 import androidx.compose.ui.text.withStyle
 import androidx.compose.ui.tooling.preview.Preview
+import androidx.compose.ui.unit.IntOffset
+import androidx.compose.ui.unit.IntRect
+import androidx.compose.ui.unit.IntSize
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.unit.dp
+import androidx.compose.ui.window.PopupPositionProvider
 import coil3.compose.AsyncImage
 import com.dhc.common.drawBalloonTail
 import com.dhc.designsystem.DhcTheme
 import com.dhc.designsystem.DhcTypoTokens
 import com.dhc.designsystem.GradientColor.fortuneBorderGradientLow
-import com.dhc.designsystem.GradientColor.fortuneGradientLow
 import com.dhc.designsystem.LocalDhcColors
 import com.dhc.designsystem.SurfaceColor
 import com.dhc.designsystem.TransparentColor
@@ -258,6 +255,7 @@ fun RewardScreen(
                         isUnlocked = it.isUnlocked,
                         isUsed = it.isUsed,
                         message = it.message,
+                        icon = it.icon,
                     )
                 },
                 onClickItem = { reward ->
@@ -419,6 +417,7 @@ private data class ReceivedReward(
     val isUnlocked: Boolean = false,
     val isUsed: Boolean = false,
     val message: String = "",
+    val icon: String = "",
 )
 
 @Composable
@@ -497,10 +496,10 @@ private fun ReceivedRewardItem(
             contentAlignment = Alignment.Center
         ) {
             if(reward.isUnlocked && reward.isUsed){
-                Image(
-                    painter = painterResource(com.dhc.designsystem.R.drawable.ico_gold_medal),
-                    contentDescription = "lock icon",
-                    modifier = Modifier.size(28.dp)
+                AsyncImage(
+                    model = reward.icon,
+                    contentDescription = "",
+                    modifier = Modifier.size(28.dp),
                 )
             } else {
                 Image(

--- a/presentation/reward/src/main/java/com/dhc/reward/model/RewardUiModel.kt
+++ b/presentation/reward/src/main/java/com/dhc/reward/model/RewardUiModel.kt
@@ -27,7 +27,7 @@ data class RewardUserUiModel(
     companion object {
         fun from(rewardUser: com.dhc.dhcandroid.model.RewardUser): RewardUserUiModel {
             return RewardUserUiModel(
-                rewardImageUrl = rewardUser.rewardImageUrl,
+                rewardImageUrl = rewardUser.image,
                 rewardLevel = "LV${rewardUser.rewardLevel.level}",
                 rewardLevelName = rewardUser.rewardLevel.name,
                 totalPoint = rewardUser.totalPoint,
@@ -43,6 +43,7 @@ data class RewardItemUiModel(
     val title: String = "",
     val isUnlocked: Boolean = false,
     val isUsed: Boolean = false,
+    val icon: String = "",
     val message: String = "",
 ) {
     companion object {
@@ -52,6 +53,7 @@ data class RewardItemUiModel(
                 title = rewardItem.title,
                 isUnlocked = rewardItem.isUnlocked,
                 isUsed = rewardItem.isUsed,
+                icon = rewardItem.icon,
                 message = rewardItem.message,
             )
         }


### PR DESCRIPTION
## 개요
🔑**이슈 링크** : https://github.com/mash-up-kr/DHC-Android/issues/519 

<img width="731" height="540" alt="Image" src="https://github.com/user-attachments/assets/658861ee-6bea-4784-a097-c51c1fc7a9ed" />

<img width="501" height="414" alt="Image" src="https://github.com/user-attachments/assets/dccf86c8-5391-4fbf-a250-2b74e307579d" />

<img width="1000" height="555" alt="Image" src="https://github.com/user-attachments/assets/dc5e15df-450f-4786-b04d-c4b7b2619b24" />


## 💻작업 내용  
- API Field Naming 통일 작업


## 🗣️To Reviwers  
-

## 👾시연 화면 (option)  

|기능A 구현|기능B 구현|  
|:---|---|
|||


## Close 
close #519 
